### PR TITLE
Flag non-loading manifest as a warning. Also, remove noisy console.log.

### DIFF
--- a/config/v2/manifest.json
+++ b/config/v2/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "Code Verify",
-    "version": "1.0.1",
+    "version": "1.0.2",
 
     "description": "An extension to verify the code running in your browser matches what was published.",
     "page_action": {

--- a/config/v3/manifest.json
+++ b/config/v3/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Code Verify",
-    "version": "1.0.1",
+    "version": "1.0.2",
 
     "description": "An extension to verify the code running in your browser matches what was published.",
     "action": {


### PR DESCRIPTION
Blocking the manifest from loading will now result in the user being warned.

Also, one of the console.log statements was way to verbose.