### PR TITLE
fix issue with DOM clobbering hasAttributes

### DIFF
--- a/src/js/contentUtils.js
+++ b/src/js/contentUtils.js
@@ -377,8 +377,8 @@ export function hasViolatingAnchorTag(htmlElement) {
 
 export function hasInvalidAttributes(htmlElement) {
   if (
-    typeof htmlElement.hasAttributes === 'function' &&
-    htmlElement.hasAttributes()
+    typeof htmlElement.attributes === 'object' &&
+    Object.keys(htmlElement.attributes).length >= 1
   ) {
     Array.from(htmlElement.attributes).forEach(elementAttribute => {
       // check first for violating attributes


### PR DESCRIPTION
It turns out you can name an html element `hasAttributes` and prevent this detection. Verified this change mitigates the issue.