### PR TITLE
Firefox fixes

### DIFF
--- a/config/v2/manifest.json
+++ b/config/v2/manifest.json
@@ -49,6 +49,7 @@
     "permissions": [
         "https://*.privacy-auditability.cloudflare.com/",
         "https://web.whatsapp.com/",
-    	"webRequest"
+        "webRequest",
+        "https://static.xx.fbcdn.net/"
     ]
 }

--- a/config/v3/manifest.json
+++ b/config/v3/manifest.json
@@ -9,7 +9,7 @@
         "default_icon": {
             "32": "default_32.png",
             "64": "default_64.png",
-           "128": "default_64@2x.png"
+            "128": "default_64@2x.png"
         },
         "default_popup": "loading.html"
     },
@@ -46,7 +46,7 @@
         }
     ],
     "permissions": [
-	"webRequest"
+        "webRequest"
     ],
     "host_permissions": [
         "https://*.privacy-auditability.cloudflare.com/",

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -108,3 +108,6 @@ export const ORIGIN_TYPE = {
   WHATSAPP: 'WHATSAPP',
   MESSENGER: 'MESSENGER',
 };
+
+// Firefox and Safari currently do not support CompressionStream
+export const DOWNLOAD_JS_ENABLED = 'CompressionStream' in window;

--- a/src/js/contentUtils.js
+++ b/src/js/contentUtils.js
@@ -10,6 +10,7 @@ import {
   KNOWN_EXTENSION_HASHES,
   MESSAGE_TYPE,
   ORIGIN_TYPE,
+  DOWNLOAD_JS_ENABLED,
 } from './config.js';
 
 const DOM_EVENTS = [
@@ -609,10 +610,14 @@ async function processJSWithSrc(script, origin, version) {
     const fileNameArr = script.src.split('/');
     const fileName = fileNameArr[fileNameArr.length - 1].split('?')[0];
     let sourceText = await sourceResponse.text();
-    sourceScripts.set(
-      fileName,
-      sourceResponseClone.body.pipeThrough(new window.CompressionStream('gzip'))
-    );
+    if (DOWNLOAD_JS_ENABLED) {
+      sourceScripts.set(
+        fileName,
+        sourceResponseClone.body.pipeThrough(
+          new window.CompressionStream('gzip')
+        )
+      );
+    }
     const sourceURLIndex = sourceText.indexOf('//# sourceURL');
     // if //# sourceURL is at the beginning of the response, sourceText should be empty, otherwise slicing indices will be (0, -1) and sourceText will be unchanged
     if (sourceURLIndex == 0) {
@@ -777,7 +782,7 @@ async function downloadJSToZip() {
 }
 
 chrome.runtime.onMessage.addListener(function (request) {
-  if (request.greeting === 'downloadSource') {
+  if (request.greeting === 'downloadSource' && DOWNLOAD_JS_ENABLED) {
     downloadJSToZip();
   } else if (request.greeting === 'nocacheHeaderFound') {
     updateCurrentState(ICON_STATE.INVALID_SOFT);

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { DOWNLOAD_JS_ENABLED } from './config.js';
+
 chrome.runtime.onMessage.addListener(message => {
   if (message && message.popup) {
     const state = message.popup.slice(message.popup.indexOf('=') + 1);
@@ -38,41 +40,54 @@ function attachListeners() {
     });
   });
   menuRowList[0].style.cursor = 'pointer';
-  menuRowList[1].addEventListener('click', () => updateDisplay('download'));
-  menuRowList[1].style.cursor = 'pointer';
 
   const downloadTextList = document.getElementsByClassName(
     'status_message_highlight'
   );
-  downloadTextList[0].addEventListener('click', () => {
-    chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
-      chrome.tabs.sendMessage(
-        tabs[0].id,
-        { greeting: 'downloadSource' },
-        () => {}
-      );
-    });
-  });
-  downloadTextList[0].style.cursor = 'pointer';
-
   const downloadSrcButton = document.getElementById('i18nDownloadSourceButton');
 
-  downloadSrcButton.onclick = () => {
-    chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
-      chrome.tabs.sendMessage(
-        tabs[0].id,
-        { greeting: 'downloadSource' },
-        () => {}
-      );
+  if (DOWNLOAD_JS_ENABLED) {
+    menuRowList[1].addEventListener('click', () => updateDisplay('download'));
+    menuRowList[1].style.cursor = 'pointer';
+
+    downloadTextList[0].addEventListener('click', () => {
+      chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
+        chrome.tabs.sendMessage(
+          tabs[0].id,
+          { greeting: 'downloadSource' },
+          () => {}
+        );
+      });
     });
-  };
+    downloadTextList[0].style.cursor = 'pointer';
 
-  downloadSrcButton.style.cursor = 'pointer';
+    downloadSrcButton.onclick = () => {
+      chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
+        chrome.tabs.sendMessage(
+          tabs[0].id,
+          { greeting: 'downloadSource' },
+          () => {}
+        );
+      });
+    };
 
-  downloadTextList[0].addEventListener('click', () =>
-    updateDisplay('download')
-  );
-  downloadTextList[0].style.cursor = 'pointer';
+    downloadSrcButton.style.cursor = 'pointer';
+
+    downloadTextList[0].addEventListener('click', () =>
+      updateDisplay('download')
+    );
+    downloadTextList[0].style.cursor = 'pointer';
+  } else {
+    menuRowList[1].remove();
+    downloadTextList[0].remove();
+    const downloadMessagePartTwo = document.getElementById(
+      'i18nValidationFailureStatusMessagePartTwo'
+    );
+    if (downloadMessagePartTwo != null) {
+      downloadMessagePartTwo.remove();
+    }
+    downloadSrcButton.remove();
+  }
 
   const learnMoreList = document.getElementsByClassName(
     'anomaly_learn_more_button'


### PR DESCRIPTION
* Add Facebook CDN (https://static.xx.fbcdn.net/) to manifest v2 so firefox can download JS sources from there
* Conditionally remove ability to download source since Firefox and Safari don't currently support the CompressionStream API