### PR TITLE
Add fb sharer plugins to exclude_matches

### DIFF
--- a/config/v2/manifest.json
+++ b/config/v2/manifest.json
@@ -40,7 +40,9 @@
                 "*://*.facebook.com/games/*",
                 "*://*.facebook.com/gaming/games/*",
                 "*://*.facebook.com/you/sales/confirm_identity",
-                "*://*.facebook.com/donate/*"
+                "*://*.facebook.com/donate/*",
+                "*://*.facebook.com/sharer/sharer.php*",
+                "*://*.facebook.com/sharer.php*"
             ],
             "js": ["contentFB.js"],
             "run_at": "document_start"

--- a/config/v3/manifest.json
+++ b/config/v3/manifest.json
@@ -39,7 +39,9 @@
                 "*://*.facebook.com/games/*",
                 "*://*.facebook.com/gaming/games/*",
                 "*://*.facebook.com/you/sales/confirm_identity",
-                "*://*.facebook.com/donate/*"
+                "*://*.facebook.com/donate/*",
+                "*://*.facebook.com/sharer/sharer.php*",
+                "*://*.facebook.com/sharer.php*"
             ],
             "js": ["contentFB.js"],
             "run_at": "document_start"


### PR DESCRIPTION
These endpoints appear in some social widgets on external/third party sites and shouldn't have access to messaging content.

Test plan:
Loaded `facebook.com/sharer.php?...` and `facebook.com/sharer/sharer.php?...` and ensured the extension couldn't access the pages.