### PR TITLE
Exclude sites that embed facebook plugins

### DIFF
--- a/config/v2/manifest.json
+++ b/config/v2/manifest.json
@@ -44,6 +44,11 @@
                 "*://*.facebook.com/sharer/sharer.php*",
                 "*://*.facebook.com/sharer.php*"
             ],
+            "exclude_globs": [
+                "*://*.facebook.com/v?/plugins/*",
+                "*://*.facebook.com/v??/plugins/*",
+                "*://*.facebook.com/v???/plugins/*"
+            ],
             "js": ["contentFB.js"],
             "run_at": "document_start"
         },

--- a/config/v3/manifest.json
+++ b/config/v3/manifest.json
@@ -43,13 +43,18 @@
                 "*://*.facebook.com/sharer/sharer.php*",
                 "*://*.facebook.com/sharer.php*"
             ],
+            "exclude_globs": [
+                "*://*.facebook.com/v?/plugins/*",
+                "*://*.facebook.com/v??/plugins/*",
+                "*://*.facebook.com/v???/plugins/*"
+            ],
             "js": ["contentFB.js"],
             "run_at": "document_start"
         },
         {
             "matches": ["*://*.whatsapp.com/*"],
             "all_frames": true,
-	        "match_about_blank": true,
+            "match_about_blank": true,
             "exclude_matches": ["*://www.whatsapp.com/", "*://*.whatsapp.com/bt-manifest/*"],
             "js": ["contentWA.js"],
             "run_at": "document_start"
@@ -61,6 +66,6 @@
     ],
     "host_permissions": [
         "https://*.privacy-auditability.cloudflare.com/",
-	    "https://web.whatsapp.com/"
+        "https://web.whatsapp.com/"
     ]
 }


### PR DESCRIPTION
* This excludes sites that might have iframes that point to something like:
"https://www.facebook.com/v2.3/plugins/like.php..."
* Also added some tab fixes to the manifest

Test Plan:
* Built the extension, and ensured it doesn't have access to and didn't attempt to validate a page that has a social plugin (e.g. https://playoverwatch.com/en-us/news/23822252/welcome-to-the-overwatch-2-beta/)
* Did a quick sanity check to ensure we don't accidentally match the excludes glob pattern for valid urls (e.g. I visited something like https://www.facebook.com/http://facebook.com/v2.3/plugins/foobar and ensured it started to verify the page).