### PR TITLE
Have Background Script Handle Tab State

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,5 +11,6 @@
         "sourceType": "module"
     },
     "rules": {
+        "no-unused-vars": ["error", {"argsIgnorePattern": "^_"}]
     }
 }

--- a/config/v2/manifest.json
+++ b/config/v2/manifest.json
@@ -10,8 +10,7 @@
             "32": "temporary-extension-icon32.png",
             "48": "temporary-extension-icon48.png",
            "128": "temporary-extension-icon128.png"
-        },
-        "default_popup": "loading.html"
+        }
     },
     "icons":  {
         "32": "temporary-extension-icon32.png",
@@ -28,7 +27,6 @@
             "all_frames": true,
             "js": ["contentMSGR.js"],
             "run_at": "document_start"
-
         },
         {
             "matches": ["*://*.facebook.com/*"],
@@ -49,7 +47,7 @@
         {
             "matches": ["*://*.whatsapp.com/*"],
             "all_frames": true,
-	        "match_about_blank": true,
+            "match_about_blank": true,
             "exclude_matches": ["*://www.whatsapp.com/", "*://*.whatsapp.com/bt-manifest/*"],
             "js": ["contentWA.js"],
             "run_at": "document_start"

--- a/config/v3/manifest.json
+++ b/config/v3/manifest.json
@@ -10,8 +10,7 @@
             "32": "default_32.png",
             "64": "default_64.png",
             "128": "default_64@2x.png"
-        },
-        "default_popup": "loading.html"
+        }
     },
     "icons":  {
         "32": "default_32.png",
@@ -27,7 +26,6 @@
             "all_frames": true,
             "js": ["contentMSGR.js"],
             "run_at": "document_start"
-
         },
         {
             "matches": ["*://*.facebook.com/*"],
@@ -48,7 +46,7 @@
         {
             "matches": ["*://*.whatsapp.com/*"],
             "all_frames": true,
-	        "match_about_blank": true,
+            "match_about_blank": true,
             "exclude_matches": ["*://www.whatsapp.com/", "*://*.whatsapp.com/bt-manifest/*"],
             "js": ["contentWA.js"],
             "run_at": "document_start"
@@ -60,6 +58,6 @@
     ],
     "host_permissions": [
         "https://*.privacy-auditability.cloudflare.com/",
-	    "https://web.whatsapp.com/"
+        "https://web.whatsapp.com/"
     ]
 }

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -12,6 +12,11 @@ import {
   ORIGIN_TYPE,
 } from './config.js';
 
+import {
+  recordContentScriptStart,
+  updateContentScriptState,
+} from './tab_state_tracker/tabStateTracker.js';
+
 const manifestCache = new Map();
 const debugCache = new Map();
 
@@ -426,6 +431,18 @@ export function handleMessages(message, sender, sendResponse) {
     const debuglist = getDebugLog(message.tabId);
     console.log('debug list is ', message.tabId, debuglist);
     sendResponse({ valid: true, debugList: debuglist });
+    return;
+  }
+
+  if (message.type === MESSAGE_TYPE.UPDATE_STATE) {
+    updateContentScriptState(sender, message.state);
+    sendResponse({ success: true });
+    return;
+  }
+
+  if (message.type === MESSAGE_TYPE.CONTENT_SCRIPT_START) {
+    recordContentScriptStart(sender);
+    sendResponse({ success: true });
     return;
   }
 }

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -22,47 +22,10 @@ const debugCache = new Map();
 
 // Emulate PageActions
 chrome.runtime.onInstalled.addListener(() => {
-  chrome.action.disable();
-});
-
-function updateIconV3(message, sender) {
-  chrome.action.setIcon({ tabId: sender.tab.id, path: message.icon.badge });
-  const popupMessage = {
-    tabId: sender.tab.id,
-    popup: message.icon.popup,
-  };
-  chrome.action.setPopup(popupMessage);
-  const messageForPopup = {
-    popup: message.icon.popup,
-    tabId: sender.tab.id,
-  };
-  chrome.runtime.sendMessage(messageForPopup);
-  chrome.action.enable(sender.tab.id);
-}
-
-function updateIconV2(message, sender) {
-  chrome.pageAction.setIcon({ tabId: sender.tab.id, path: message.icon.badge });
-  const popupMessage = {
-    tabId: sender.tab.id,
-    popup: message.icon.popup,
-  };
-  chrome.pageAction.setPopup(popupMessage);
-  const messageForPopup = {
-    popup: message.icon.popup,
-    tabId: sender.tab.id,
-  };
-  chrome.runtime.sendMessage(messageForPopup);
-  chrome.pageAction.show(sender.tab.id);
-}
-
-function updateIcon(message, sender) {
-  console.log('background messages are ', message);
-  if (chrome.pageAction) {
-    updateIconV2(message, sender);
-  } else {
-    updateIconV3(message, sender);
+  if (chrome.runtime.getManifest().manifest_version >= 3) {
+    chrome.action.disable();
   }
-}
+});
 
 function addDebugLog(tabId, debugMessage) {
   let tabDebugList = debugCache.get(tabId);
@@ -265,10 +228,6 @@ export function handleMessages(message, sender, sendResponse) {
         }
       }
     );
-    return;
-  }
-  if (message.type == MESSAGE_TYPE.UPDATE_ICON) {
-    updateIcon(message, sender);
     return;
   }
 

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -22,6 +22,33 @@ export const STATES = {
   TIMEOUT: 'TIMEOUT',
 };
 
+const ICONS = {
+  DEFAULT: {
+    32: 'default_32.png',
+    64: 'default_64.png',
+    128: 'default_64@2x.png',
+  },
+  FAILURE: {
+    32: 'failure_32.png',
+  },
+  RISK: {
+    32: 'risk_32.png',
+  },
+  VALID: {
+    32: 'validated_32.png',
+  },
+};
+
+export const STATES_TO_ICONS = {
+  [STATES.START]: ICONS.DEFAULT,
+  [STATES.PROCESSING]: ICONS.DEFAULT,
+  [STATES.IGNORE]: ICONS.DEFAULT,
+  [STATES.INVALID]: ICONS.FAILURE,
+  [STATES.RISK]: ICONS.RISK,
+  [STATES.VALID]: ICONS.VALID,
+  [STATES.TIMEOUT]: ICONS.RISK,
+};
+
 export const ICON_STATE = {
   DEFAULT: { badge: 'icon-badge.svg', popup: 'popup.html?state=loading' },
   INVALID_HARD: {
@@ -104,7 +131,6 @@ export const MESSAGE_TYPE = {
   LOAD_MANIFEST: 'LOAD_MANIFEST',
   POPUP_STATE: 'POPUP_STATE',
   RAW_JS: 'RAW_JS',
-  UPDATE_ICON: 'UPDATE_ICON',
   UPDATE_STATE: 'UPDATE_STATE',
   STATE_UPDATED: 'STATE_UPDATED',
   CONTENT_SCRIPT_START: 'CONTENT_SCRIPT_START',

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -5,6 +5,23 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+export const STATES = {
+  // Starting state for all frames/tabs
+  START: 'START',
+  // Tab is processing scripts
+  PROCESSING: 'PROCESSING',
+  // Disable the extension (it shouldn't be running on this tab)
+  IGNORE: 'IGNORE',
+  // Script verification against the manifest failed.
+  INVALID: 'INVALID',
+  // Unknown inline script from an extension was found
+  RISK: 'RISK',
+  // All script verifications succeeded
+  VALID: 'VALID',
+  // Timed out waiting for the manifest to be available on the page
+  TIMEOUT: 'TIMEOUT',
+};
+
 export const ICON_STATE = {
   DEFAULT: { badge: 'icon-badge.svg', popup: 'popup.html?state=loading' },
   INVALID_HARD: {
@@ -88,6 +105,9 @@ export const MESSAGE_TYPE = {
   POPUP_STATE: 'POPUP_STATE',
   RAW_JS: 'RAW_JS',
   UPDATE_ICON: 'UPDATE_ICON',
+  UPDATE_STATE: 'UPDATE_STATE',
+  STATE_UPDATED: 'STATE_UPDATED',
+  CONTENT_SCRIPT_START: 'CONTENT_SCRIPT_START',
 };
 
 export const ORIGIN_HOST = {

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -49,52 +49,6 @@ export const STATES_TO_ICONS = {
   [STATES.TIMEOUT]: ICONS.RISK,
 };
 
-export const ICON_STATE = {
-  DEFAULT: { badge: 'icon-badge.svg', popup: 'popup.html?state=loading' },
-  INVALID_HARD: {
-    // badge: 'error-badge.svg',
-    badge: {
-      32: 'failure_32.png',
-    },
-    popup: 'popup.html?state=error',
-  },
-  INVALID_SOFT: {
-    // badge: 'error-badge.svg',
-    badge: {
-      32: 'failure_32.png',
-    },
-    popup: 'popup.html?state=error',
-  },
-  PROCESSING: {
-    // badge: 'icon-badge.svg',
-    badge: {
-      32: 'default_32.png',
-    },
-    popup: 'popup.html?state=loading',
-  },
-  VALID: {
-    // badge: 'validated-badge.svg',
-    badge: {
-      32: 'validated_32.png',
-    },
-    popup: 'popup.html?state=valid',
-  },
-  WARNING_RISK: {
-    // badge: 'warning-badge.svg',
-    badge: {
-      32: 'risk_32.png',
-    },
-    popup: 'popup.html?state=warning_risk',
-  },
-  WARNING_TIMEOUT: {
-    // badge: 'warning-badge.svg',
-    badge: {
-      32: 'risk_32.png',
-    },
-    popup: 'popup.html?state=warning_timeout',
-  },
-};
-
 export const KNOWN_EXTENSION_HASHES = [
   '', // Chrome - Dynamic: StopAll Ads
   '727bfede71f473991faeb7f4b65632c93e7f7d17189f1b3d952cd990cd150808', // Chrome and Edge: Avast Online Security & Privacy v21.0.101

--- a/src/js/tab_state_tracker/FrameStateMachine.js
+++ b/src/js/tab_state_tracker/FrameStateMachine.js
@@ -1,0 +1,18 @@
+import StateMachine from './StateMachine.js';
+
+/**
+ * Tracks the extension's state for each frame. It'll notify the overall tab's
+ * state machine of any changes. The tab may or may not choose to apply those
+ * changes based on the current states of the rest of its frames
+ * (see TabStateMachine.js).
+ */
+export default class FrameStateMachine extends StateMachine {
+  constructor(tabStateMachine) {
+    super();
+    this._tabStateMachine = tabStateMachine;
+  }
+
+  onStateUpdated() {
+    this._tabStateMachine.updateStateIfValid(this.getState());
+  }
+}

--- a/src/js/tab_state_tracker/StateMachine.js
+++ b/src/js/tab_state_tracker/StateMachine.js
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { STATES } from '../config.js';
+
+// Table of possible transitions from one state to another. The entries for
+// each transition can be:
+//   (a) a boolean indicating if the transition to that state is valid
+//   (b) another state to transition to should a transition to the 'from' state
+//       is attempted.
+const STATE_TRANSITIONS = {
+  [STATES.START]: {
+    [STATES.START]: true,
+    [STATES.PROCESSING]: true,
+    [STATES.IGNORE]: true,
+  },
+  [STATES.PROCESSING]: {
+    [STATES.PROCESSING]: true,
+    [STATES.INVALID]: true,
+    [STATES.RISK]: true,
+    [STATES.VALID]: true,
+    [STATES.TIMEOUT]: true,
+  },
+  [STATES.IGNORE]: {
+    [STATES.IGNORE]: true,
+    [STATES.INVALID]: true,
+    // Attempting to go from IGNORE to anything other than INVALID is bad and
+    // should send you to an INVALID state. Either all frames in the tab are
+    // being checked to some extent, or all should be ignored by the extension.
+    // Nothing in between.
+    [STATES.START]: STATES.INVALID,
+    [STATES.PROCESSING]: STATES.INVALID,
+    [STATES.RISK]: STATES.INVALID,
+    [STATES.VALID]: STATES.INVALID,
+    [STATES.TIMEOUT]: STATES.INVALID,
+  },
+  [STATES.INVALID]: {
+    [STATES.INVALID]: true,
+  },
+  [STATES.RISK]: {
+    [STATES.RISK]: true,
+  },
+  [STATES.VALID]: {
+    [STATES.VALID]: true,
+    [STATES.PROCESSING]: true,
+    [STATES.INVALID]: true,
+    [STATES.IGNORE]: STATES.INVALID,
+  },
+  [STATES.TIMEOUT]: {
+    [STATES.TIMEOUT]: true,
+  },
+};
+
+/**
+ * State machine that transitions through the states listed above. This is used
+ * to track the extension's state of the overall tab, and for individual frames
+ * within that tab.
+ */
+export default class StateMachine {
+  constructor() {
+    this._state = STATES.START;
+  }
+
+  getState() {
+    return this._state;
+  }
+
+  updateStateIfValid(newState) {
+    // You messed up.
+    if (!(newState in STATES)) {
+      console.error('State', newState, 'does not exist!');
+      this._setState(STATES.INVALID);
+      return;
+    }
+
+    let skipState = STATE_TRANSITIONS[this._state][newState];
+    if (typeof skipState === 'string') {
+      this.updateStateIfValid(skipState);
+      return;
+    } else if (skipState) {
+      this._setState(newState);
+    }
+  }
+
+  _setState(newState) {
+    const oldState = this._state;
+    this._state = newState;
+    if (oldState !== newState) {
+      this.onStateUpdated();
+    }
+  }
+
+  onStateUpdated() {}
+}

--- a/src/js/tab_state_tracker/TabStateMachine.js
+++ b/src/js/tab_state_tracker/TabStateMachine.js
@@ -1,0 +1,42 @@
+import { STATES } from '../config';
+
+import StateMachine from './StateMachine.js';
+import FrameStateMachine from './FrameStateMachine.js';
+
+/**
+ * Tracks the extension's state based on the states of the individual frames
+ * in it.
+ */
+export default class TabStateMachine extends StateMachine {
+  constructor(tabId) {
+    super();
+    this._tabId = tabId;
+    this._frameStates = {};
+  }
+
+  addFrameStateMachine(frameId) {
+    this._frameStates[frameId] = new FrameStateMachine(this);
+  }
+
+  updateStateForFrame(frameId, newState) {
+    if (!(frameId in this._frameStates)) {
+      throw new Error(
+        `State machine for frame: ${frameId} does not exist for tab: ${this._tabId}`
+      );
+    }
+    this._frameStates[frameId].updateStateIfValid(newState);
+  }
+
+  updateStateIfValid(newState) {
+    // Only update the tab's state to VALID if all of it's frames are VALID
+    if (
+      newState === STATES.VALID &&
+      !Object.values(this._frameStates).every(
+        fsm => fsm.getState() === STATES.VALID
+      )
+    ) {
+      return;
+    }
+    super.updateStateIfValid(newState);
+  }
+}

--- a/src/js/tab_state_tracker/tabStateTracker.js
+++ b/src/js/tab_state_tracker/tabStateTracker.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import TabStateMachine from './TabStateMachine.js';
+
+const tabStateTracker = new Map();
+
+chrome.tabs.onRemoved.addListener((tabId, _removeInfo) => {
+  tabStateTracker.delete(tabId);
+});
+chrome.tabs.onReplaced.addListener((_addedTabId, removedTabId) => {
+  tabStateTracker.delete(removedTabId);
+});
+
+function getTabStateMachine(tabId) {
+  if (!tabStateTracker.has(tabId)) {
+    tabStateTracker.set(tabId, new TabStateMachine(tabId));
+  }
+  return tabStateTracker.get(tabId);
+}
+
+export function recordContentScriptStart(sender) {
+  // This is a top-level frame initializing
+  if (sender.frameId === 0) {
+    tabStateTracker.delete(sender.tab.id);
+  }
+  getTabStateMachine(sender.tab.id).addFrameStateMachine(sender.frameId);
+}
+
+export function updateContentScriptState(sender, newState) {
+  getTabStateMachine(sender.tab.id).updateStateForFrame(
+    sender.frameId,
+    newState
+  );
+}


### PR DESCRIPTION
## Problem

tl;dr; The way the extension's icon and popup state get handled right now has a race condition.
Right now the extension's icon and popup state for a particular tab is handled/set by the extension's content scripts that are running on that tab. The issue with that is we can have multiple content scripts running per frame on the tab (e.g. one for the top-level frame/main page, and another for an iframe nested in that page). This means that if a particular content script sets that icon state to a "final" state, such as showing that verification failed for the page, another content script on the same tab can override that state, and change it to something else, like verification succeeded. For example, at:
* `t=0`: top frame content script sets state to PROCESSING
* `t=1`: nested iframe content script sets state to PROCESSING
* `t=2`: top frame content script sets state to INVALID
* `t=3`: nested iframe content script sets state to VALID

## Solution
The solution here is to have the extension's _single_ background script keep track of the state of all relevant tabs. It does so by keeping track of, and updating, the state of all frames within that tab, and resolving the overall tab's state based on the states of its frames. The states for both frames and tabs will be kept track of using a state machine. Each content script will push state transitions to the background script to update the state machine for its frame. If the transitions is valid and gets performed, the frame's state machine attempts the exact same state transition to the tab's state machine, which if valid will also get performed and will result in the icon and popup being updated. Luckily state machines for frames and tabs are same, with a few constraints that are specific to just tabs.

### State Machine

![Code Verify Extension State Machine Diagram](https://user-images.githubusercontent.com/4382342/184079434-40fd5fe7-6165-46bd-9e8c-4286fae9c1ce.png)
(Source: [Google Drawing](https://docs.google.com/drawings/d/1pDFHpLlpk6mNqfqugvn45KDEPvQuCgFfzui2IbbofS0/edit))

The tab-specific constraints are:
* Only re-initialize to a START state if receiving a "start" message from the top-level frame's content script (meaning a page navigation has occurred) OR if receiving a "start" or state transition message for the tab for the first time
* Only move to a VALID state if all frame states are VALID.

### Drawbacks

This solution isn't perfect for _all_ BT-related cases. The glaring flaw here is that the tab's state won't really get reset if a content script doesn't run for the top-level frame but only for nested iframes. This is fine for now since it's sufficient for Meta's use-case: any nested iframe that has a facebook domain does not have messaging enabled and (for now) is going to be ignored by the extension. Any Meta endpoint that does have messaging enabled should not be iframe-able.

## Test Plan

For all supported browsers, I visited the following endpoints and ensured they hit their end state:

* START: https://www.facebook.com
* PROCESSING: https://www.facebook.com (initially before hitting valid).
* VALID: https://www.facebook.com/
* INVALID: https://playoverwatch.com/en-us/news/23822252/welcome-to-the-overwatch-2-beta/
  * due to iframe-d like plugin 
* TIMEOUT: https://www.facebook.com/help/728172628487328
* RISK: https://www.facebook.com/ with any one of these [known extensions installed](https://github.com/facebookincubator/meta-code-verify/blob/87b1af28a3f02e9cd461643f463bcd8eadbd309a/src/js/config.js#L54-L82) (i.e. Vue.js DevTools and AdGuard)

There are no endpoints resulting in an IGNORE state since that's not being used right now. See #185.

## Other Changes That I Snuck In

* Fixed a bug where state changes for a single tab would be propagated to all popups currently being displayed.
* Fixed an exception that occurred in the `onInstalled` listener on Firefox due to manifest V2 vs V3 compatibility issues.
* Added high-res versions of icons if available.
