### PR TITLE
Add ability to ignore pathnames inside content script

### DIFF
--- a/config/v2/manifest.json
+++ b/config/v2/manifest.json
@@ -32,15 +32,6 @@
             "matches": ["*://*.facebook.com/*"],
             "all_frames": true,
             "match_about_blank": true,
-            "exclude_matches": [
-                "*://*.facebook.com/settings/*",
-                "*://*.facebook.com/games/*",
-                "*://*.facebook.com/gaming/games/*",
-                "*://*.facebook.com/you/sales/confirm_identity",
-                "*://*.facebook.com/donate/*",
-                "*://*.facebook.com/sharer/sharer.php*",
-                "*://*.facebook.com/sharer.php*"
-            ],
             "js": ["contentFB.js"],
             "run_at": "document_start"
         },
@@ -48,7 +39,11 @@
             "matches": ["*://*.whatsapp.com/*"],
             "all_frames": true,
             "match_about_blank": true,
-            "exclude_matches": ["*://www.whatsapp.com/", "*://*.whatsapp.com/bt-manifest/*"],
+            "exclude_matches": [
+                "*://www.whatsapp.com/",
+                "*://*.whatsapp.com/bt-manifest/*",
+                "*://faq.whatsapp.com/*"
+            ],
             "js": ["contentWA.js"],
             "run_at": "document_start"
         }

--- a/config/v3/manifest.json
+++ b/config/v3/manifest.json
@@ -31,15 +31,6 @@
             "matches": ["*://*.facebook.com/*"],
             "all_frames": true,
             "match_about_blank": true,
-            "exclude_matches": [
-                "*://*.facebook.com/settings/*",
-                "*://*.facebook.com/games/*",
-                "*://*.facebook.com/gaming/games/*",
-                "*://*.facebook.com/you/sales/confirm_identity",
-                "*://*.facebook.com/donate/*",
-                "*://*.facebook.com/sharer/sharer.php*",
-                "*://*.facebook.com/sharer.php*"
-            ],
             "js": ["contentFB.js"],
             "run_at": "document_start"
         },
@@ -47,7 +38,11 @@
             "matches": ["*://*.whatsapp.com/*"],
             "all_frames": true,
             "match_about_blank": true,
-            "exclude_matches": ["*://www.whatsapp.com/", "*://*.whatsapp.com/bt-manifest/*"],
+            "exclude_matches": [
+                "*://www.whatsapp.com/",
+                "*://*.whatsapp.com/bt-manifest/*",
+                "*://faq.whatsapp.com/*"
+            ],
             "js": ["contentWA.js"],
             "run_at": "document_start"
         }

--- a/src/js/contentUtils.js
+++ b/src/js/contentUtils.js
@@ -772,8 +772,27 @@ function parseFailedJson(queuedJsonToParse) {
   }
 }
 
-export function startFor(origin) {
+function isPathnameExcluded(excludedPathnames) {
+  let pathname = location.pathname;
+  if (!pathname.endsWith('/')) {
+    pathname = pathname + '/';
+  }
+  return excludedPathnames.some(rule => {
+    if (typeof rule === 'string') {
+      return pathname === rule;
+    } else {
+      const match = pathname.match(rule);
+      return match != null && match[0] === pathname;
+    }
+  });
+}
+
+export function startFor(origin, excludedPathnames = []) {
   chrome.runtime.sendMessage({ type: MESSAGE_TYPE.CONTENT_SCRIPT_START });
+  if (isPathnameExcluded(excludedPathnames)) {
+    updateCurrentState(STATES.IGNORE);
+    return;
+  }
   let isUserLoggedIn = false;
   if ([ORIGIN_TYPE.FACEBOOK, ORIGIN_TYPE.MESSENGER].includes(origin)) {
     const cookies = document.cookie.split(';');

--- a/src/js/detectFBMeta.js
+++ b/src/js/detectFBMeta.js
@@ -8,4 +8,53 @@
 import { ORIGIN_TYPE } from './config.js';
 import { startFor } from './contentUtils.js';
 
-startFor(ORIGIN_TYPE.FACEBOOK);
+// Pathnames that do not currently have messaging enabled and are not BT
+// compliant/
+// NOTE: All pathnames checked against this list will be surrounded by '/'
+const EXCLUDED_PATHNAMES = [
+  /**
+   * Settings
+   */
+  '/settings/',
+  /\/[^/]+?\/settings\/$/, // Page settings
+
+  /**
+   * Games
+   */
+  '/games/',
+  // Anything in the /games pathname except /games/instantgames/
+  /\/games\/(?:(?!instantgames\/)).*$/,
+  '/gaming/games/',
+  // Anything in the /gaming/games pathname except /gaming/games/instantgames/
+  /\/gaming\/games\/(?:(?!instantgames\/)).*$/,
+
+  /**
+   * Share plugin
+   */
+  '/sharer.php/',
+  '/sharer/',
+  /\/sharer\/sharer.php.*$/,
+
+  /**
+   * Like plugin
+   */
+  // e.g. /v2.5/plugins/like.php
+  /\/v[\d.]+\/plugins\/like.php\/.*$/,
+
+  /**
+   * Help center articles
+   */
+  /\/help\/.*$/,
+
+  /**
+   * Marketplace
+   */
+  '/marketplace/you/sales/confirm_identity/',
+
+  /**
+   * Fundraisers
+   */
+  /\/donate\/.*$/,
+];
+
+startFor(ORIGIN_TYPE.FACEBOOK, EXCLUDED_PATHNAMES);


### PR DESCRIPTION
**NOTE:** This depends on PR #184, which should ideally be merged first and have its branch deleted so that this one merges directly onto `main`, and we get separate commits on main for each PR.

Our `exclude_matches` constraint on the manifest can be too greedy and can match with an endpoint that _should_ be checked by the extension, which is bad. To fix this, we can have the content script run on all facebook domains and use more stricter RegExps on the pathnames to determine whether or not the page should be checked by the extension. If they shouldn't they can push an IGNORE state transition, which'll either:

1. Change the tab's state to IGNORE and disable the extension's icon/popup, or
2. Change the tab's state to INVALID if there are other frames that are attempting to set their state to anything other than IGNORE (meaning they're actually checking for BT compliance); either all relevant (fb) frames in the tab are ignored by the extension or none are, anything in between is invalid.

Note that there still are some expressions that I've copied from the manifest that will always be too greedy in the sense that they might potentially resolve to a 404 page that should be checked by the extension. To solve for this, we can eventually re-enable the extension if we detect that it has messaging enabled by inspecting the DOM. This can result in some false negatives (extension stating a page that should never have been checked by it is invalid), but it can at least give a much stronger guarantee of not having false positives (the extension ignores a page that it should check for BT compliance).

## Test Plan

Tested the following urls to ensure they got ignored:
* facebook.com/settings
* facebook.com/<test page vanity>/settings
* facebook.com/games
* facebook.com/games/fdsafdsa/fdfasf
* facebook.com/gaming/games
* facebook.com/gaming/games/fdafdsaf?q=fdsas
* facebook.com/sharer.php
* facebook.com/sharer/
* facebook.com/sharer/sharer.php
* facebook.com/sharer/sharer.phpfdsfdas
* facebook.com/sharer/sharer.php/fdfdsafd
* facebook.com/v2.5/plugins/like.php
* facebook.com/help/728172628487328

Tested the following urls to ensure the **did not** get ignored:
* facebook.com/fdsaf/fdfdsa/settings
* facebook.com/<test page vanity>
* facebook.com/games/instantgames/
* facebook.com/games/instantgames/fdsfsa
* facebook.com/gaming/games/instantgames
* facebook.com/gaming/games/instantgames/fdsfsa
* facebook.com/sharer/fdfdsa
* facebook.com/sharer.php/fdfdsafds

### Some other changes
* Have facebook help center pages be ignored by the extension
* Have faq.whatsapp.com be ignored by the extension