### PR TITLE
Update popup help link logic to not use "tabs" permission

### DIFF
--- a/config/v2/manifest.json
+++ b/config/v2/manifest.json
@@ -51,7 +51,6 @@
     "permissions": [
         "https://*.privacy-auditability.cloudflare.com/",
         "https://web.whatsapp.com/",
-        "tabs",
         "webRequest",
         "https://static.xx.fbcdn.net/"
     ]

--- a/config/v3/manifest.json
+++ b/config/v3/manifest.json
@@ -48,7 +48,6 @@
         }
     ],
     "permissions": [
-        "tabs",
         "webRequest"
     ],
     "host_permissions": [

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -207,29 +207,6 @@ function getDebugLog(tabId) {
 
 export function handleMessages(message, sender, sendResponse) {
   console.log('in handle messages ', message);
-  // just check for any of the popup urls
-  if (message.popup_help_wa) {
-    chrome.tabs.query(
-      { active: true, lastFocusedWindow: true },
-      function (tabs) {
-        const currentHostname = new URL(tabs[0].url).hostname;
-        if (currentHostname.includes('whatsapp')) {
-          chrome.tabs.create({
-            url: message.popup_help_wa,
-          });
-        } else if (currentHostname.includes('messenger')) {
-          chrome.tabs.create({
-            url: message.popup_help_msgr,
-          });
-        } else {
-          chrome.tabs.create({
-            url: message.popup_help_fb,
-          });
-        }
-      }
-    );
-    return;
-  }
 
   if (message.type == MESSAGE_TYPE.LOAD_MANIFEST) {
     // validate manifest
@@ -394,13 +371,13 @@ export function handleMessages(message, sender, sendResponse) {
   }
 
   if (message.type === MESSAGE_TYPE.UPDATE_STATE) {
-    updateContentScriptState(sender, message.state);
+    updateContentScriptState(sender, message.state, message.origin);
     sendResponse({ success: true });
     return;
   }
 
   if (message.type === MESSAGE_TYPE.CONTENT_SCRIPT_START) {
-    recordContentScriptStart(sender);
+    recordContentScriptStart(sender, message.origin);
     sendResponse({ success: true });
     return;
   }

--- a/src/js/contentUtils.js
+++ b/src/js/contentUtils.js
@@ -253,6 +253,7 @@ function updateCurrentState(state) {
   chrome.runtime.sendMessage({
     type: MESSAGE_TYPE.UPDATE_STATE,
     state,
+    origin: currentOrigin,
   });
 }
 
@@ -788,7 +789,10 @@ function isPathnameExcluded(excludedPathnames) {
 }
 
 export function startFor(origin, excludedPathnames = []) {
-  chrome.runtime.sendMessage({ type: MESSAGE_TYPE.CONTENT_SCRIPT_START });
+  chrome.runtime.sendMessage({
+    type: MESSAGE_TYPE.CONTENT_SCRIPT_START,
+    origin,
+  });
   if (isPathnameExcluded(excludedPathnames)) {
     updateCurrentState(STATES.IGNORE);
     return;

--- a/src/js/tab_state_tracker/TabStateMachine.js
+++ b/src/js/tab_state_tracker/TabStateMachine.js
@@ -21,9 +21,10 @@ function getChromeV3Action() {
  * in it.
  */
 export default class TabStateMachine extends StateMachine {
-  constructor(tabId) {
+  constructor(tabId, origin) {
     super();
     this._tabId = tabId;
+    this._origin = origin;
     this._frameStates = {};
   }
 
@@ -66,7 +67,7 @@ export default class TabStateMachine extends StateMachine {
       chromeAction.enable(this._tabId);
       chromeAction.setPopup({
         tabId: this._tabId,
-        popup: `popup.html?tab_id=${this._tabId}&state=${state}`,
+        popup: `popup.html?tab_id=${this._tabId}&state=${state}&origin=${this._origin}`,
       });
       // Broadcast state update for relevant popup to update its contents.
       chrome.runtime.sendMessage({

--- a/src/js/tab_state_tracker/tabStateTracker.js
+++ b/src/js/tab_state_tracker/tabStateTracker.js
@@ -16,23 +16,25 @@ chrome.tabs.onReplaced.addListener((_addedTabId, removedTabId) => {
   tabStateTracker.delete(removedTabId);
 });
 
-function getTabStateMachine(tabId) {
+function getOrCreateTabStateMachine(tabId, origin) {
   if (!tabStateTracker.has(tabId)) {
-    tabStateTracker.set(tabId, new TabStateMachine(tabId));
+    tabStateTracker.set(tabId, new TabStateMachine(tabId, origin));
   }
   return tabStateTracker.get(tabId);
 }
 
-export function recordContentScriptStart(sender) {
+export function recordContentScriptStart(sender, origin) {
   // This is a top-level frame initializing
   if (sender.frameId === 0) {
     tabStateTracker.delete(sender.tab.id);
   }
-  getTabStateMachine(sender.tab.id).addFrameStateMachine(sender.frameId);
+  getOrCreateTabStateMachine(sender.tab.id, origin).addFrameStateMachine(
+    sender.frameId
+  );
 }
 
-export function updateContentScriptState(sender, newState) {
-  getTabStateMachine(sender.tab.id).updateStateForFrame(
+export function updateContentScriptState(sender, newState, origin) {
+  getOrCreateTabStateMachine(sender.tab.id, origin).updateStateForFrame(
     sender.frameId,
     newState
   );


### PR DESCRIPTION
**NOTE:** This depends on PR #185, which should ideally be merged first and have its branch deleted so that this one merges directly onto `main`, and we get separate commits on main for each PR.

Right now, we use the `"tabs"` permission to access the url of the current tab the popup is being accessed on to know which site's help center article (FB, Messenger, or WhatsApp) to open up when a Learn More link is clicked on. This results in a "Read your browsing history" permission message showing up for the extension:

![Current Permission Dialogue For Extension](https://user-images.githubusercontent.com/4382342/184084978-47999130-46fb-4252-a500-fdf4c9a4e178.png)

We don't actually need this permission. [According to Chrome's docs](https://developer.chrome.com/docs/extensions/reference/tabs/#perms) we can use optional `host_permission`s to read the tab's url for specific domains. Or, alternatively, what this PR does is just have the content scripts that are running for the tab send over their origin type with their start message. This then gets stored in the tab's state machine, and sent over to the popup via a query param. The popup's source can just create the new tab themselves with the correct help center article url using this information.

This ends up giving the extension the following permission dialogue:

![New Permission Dialogue For Extension](https://user-images.githubusercontent.com/4382342/184086503-d0ec1370-50ed-490f-9e36-5d29789a1ff2.png)

## Test Plan

To test this I pushed a bunch of different states for a tabs via DevTools for the background script for each domain, and ensured Learn More links open new tabs to the correct help center article.
