### PR TITLE
Use rollup to copy static files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,5 +11,6 @@
         "sourceType": "module"
     },
     "rules": {
+        "no-unused-vars": ["error", {"argsIgnorePattern": "^_"}]
     }
 }

--- a/build/rollup-plugin-static-files.mjs
+++ b/build/rollup-plugin-static-files.mjs
@@ -1,0 +1,66 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as process from 'process';
+
+async function readDirRecursive(dirPath) {
+  const fileNames = await fs.readdir(dirPath);
+  const files = [];
+  await Promise.all(
+    fileNames.map(async fileName => {
+      const stats = await fs.stat(path.resolve(dirPath, fileName));
+      if (stats.isDirectory()) {
+        files.push(
+          ...(await readDirRecursive(path.resolve(dirPath, fileName)))
+        );
+      } else {
+        files.push(path.resolve(dirPath, fileName));
+        return Promise.resolve();
+      }
+    })
+  );
+  return files;
+}
+
+const DEFAULT_OPTIONS = {
+  keepDir: false,
+};
+
+/**
+ * A simple plugin that copies files from a source directory to output.dir
+ *
+ * @param {Array<string>} dirs Directories to recursively copy files from
+ * @param {Object} options Plugin options
+ * @param {boolean} option.keepDir Include directory in output directory
+ *    (e.g. if true, and your directory is `locales/`, output directory will
+ *    have: `dist/locales/<contents of locales/>`, vs. just
+ *    `dist/<contents of locales>`)
+ * @returns Rollup.PluginImpl
+ */
+export default function rollupPluginStaticFiles(dirs = [], options) {
+  const { keepDir } = {...DEFAULT_OPTIONS, ...options};
+  if (!Array.isArray(dirs)) {
+    dirs = [dirs];
+  }
+  return {
+    name: 'rollup-plugin-static-files',
+
+    async generateBundle(_options, _bundle, _isWrite) {
+      const rootDir = process.cwd();
+      await Promise.all(
+        dirs.map(async dir => {
+          const dirPath = path.resolve(rootDir, dir);
+          const filePaths = await readDirRecursive(path.resolve(rootDir, dir));
+          return await Promise.all(
+            filePaths.map(async filePath => {
+              this.emitFile({
+                type: 'asset',
+                fileName: path.relative(keepDir ? rootDir : dirPath, filePath),
+                source: await fs.readFile(filePath),
+              });
+            })
+          );
+        })
+      );
+    },
+  };
+}

--- a/package.json
+++ b/package.json
@@ -8,14 +8,13 @@
   "license": "MIT",
   "type": "module",
   "private": true,
+  "engines": {
+    "node": "^18.0.0"
+  },
   "scripts": {
-    "build-local-dev": "yarn clean && yarn lint && yarn makeBundle && yarn copyStaticFilesAndConfig",
+    "build-local-dev": "yarn clean && yarn lint && yarn makeBundle",
     "clean": "rm -rf dist/chrome/* dist/edge/* dist/firefox/*",
     "lint": "yarn makePrettier && yarn run eslint src/js/**",
-    "copyChromeFilesAndConfig": "cp config/v3/* dist/chrome && cp images/* dist/chrome && cp src/html/* dist/chrome && cp src/css/* dist/chrome && cp -r _locales dist/chrome/",
-    "copyEdgeFilesAndConfig": "cp config/v3/* dist/edge && cp images/* dist/edge && cp src/html/* dist/edge && cp src/css/* dist/edge && cp -r _locales dist/edge",
-    "copyFirefoxFilesAndConfig": "cp config/v2/* dist/firefox && cp images/* dist/firefox && cp src/html/* dist/firefox && cp src/css/* dist/firefox && cp -r _locales dist/firefox",
-    "copyStaticFilesAndConfig": "yarn copyChromeFilesAndConfig && yarn copyEdgeFilesAndConfig && yarn copyFirefoxFilesAndConfig",
     "makeBundle": "yarn run rollup -c",
     "makePrettier": "yarn run prettier --write \"src/**/*.js\"",
     "test": "yarn lint && node --experimental-vm-modules --no-warnings node_modules/jest/bin/jest.js"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,5 @@
+import staticFiles from './build/rollup-plugin-static-files.mjs';
+
 export default [
     {
         input: 'src/js/detectWAMeta.js',
@@ -55,14 +57,21 @@ export default [
         input: 'src/js/popup.js',
         output: [{
             file: 'dist/chrome/popup.js',
-            format: 'iife'
+            format: 'iife',
+            plugins: [staticFiles('config/v3/')],
         }, {
             file: 'dist/edge/popup.js',
-            format: 'iife'
+            format: 'iife',
+            plugins: [staticFiles('config/v3/')],
         }, {
             file: 'dist/firefox/popup.js',
-            format: 'iife'
-        }]
+            format: 'iife',
+            plugins: [staticFiles('config/v2/')],
+        }],
+        plugins: [
+            staticFiles(['images/', 'src/css/', 'src/html/']),
+            staticFiles('_locales/', {keepDir: true}),
+        ],
     }
 
 ];


### PR DESCRIPTION
Recent development on this codebase has made me  **really** want some sort of watch functionality that can re-bundle as soon as a relevant file changes. Luckily Rollup has that functionality, and we'll just need to merge other build commands, like copying files, formatting and linting, over to rollup, which should be fine since rollup was designed to have a plugin system that allows for intermediate custom steps in the build process.

This PR has rollup handle copying files over. I couldn't really find an existing plugin that has the functionality/flexibility that I was looking for, so I built a simple custom plugin that just uses node's `fs` module to perform file operations. This change has the added benefit of making the file operations platform agnostic and therefore able to run on non-POSIX environments (i.e. windows cmd or powershell). Other dependant/stacked PRs will move over the rest of the functionality.

In an ideal world we'd have the relevant `.js` files require these assets and use rollup's resolving system to detect that they need to copied over, but that's a bit overkill for now.

## Test Plan

Ran `yarn build-local-dev` and ensured `dist/*` directories contained the correct files. I also installed the unpacked extensions to Chrome and Firefox and ensured that the assets (e.g. icon images, i18n text) were displayed.