### PR TITLE
Have rollup clean output dirs once before each build

### DIFF
--- a/build/rollup-plugin-clean-once.mjs
+++ b/build/rollup-plugin-clean-once.mjs
@@ -1,0 +1,45 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as process from 'process';
+
+async function genHasAccess(path) {
+  try {
+    await fs.access(path, fs.constants.R_OK | fs.constants.W_OK);
+    return true;
+  } catch (_err) {
+    return false;
+  }
+}
+
+const deletedDirs = new Set();
+
+/**
+ * A simple plugin that deletes output directories *once* (so we don't delete
+ * them over and over again when running `watch`, and to not mess up subsquent
+ * rollup entries that use the same directory and the same plugin).
+ */
+export default function rollupPluginCleanOnce() {
+  return {
+    name: 'rollup-plugin-clean',
+
+    async generateBundle(options, _bundle, isWrite) {
+      // No point in cleaning if rollup isn't going to write the output
+      if (!isWrite) {
+        return;
+      }
+      const rootDir = process.cwd();
+      const dirToDelete = options.dir
+        ? path.resolve(rootDir, options.dir)
+        : path.dirname(path.resolve(rootDir, options.file));
+      // Only delete once.
+      if (deletedDirs.has(dirToDelete)) {
+        return;
+      }
+      deletedDirs.add(dirToDelete);
+      if (await genHasAccess(dirToDelete)) {
+        console.log('Deleting:', dirToDelete);
+        await fs.rm(dirToDelete, { recursive: true });
+      }
+    },
+  };
+}

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "node": "^18.0.0"
   },
   "scripts": {
-    "build-local-dev": "yarn clean && yarn lint && yarn makeBundle",
-    "clean": "rm -rf dist/chrome/* dist/edge/* dist/firefox/*",
+    "build-local-dev": "yarn lint && yarn makeBundle",
     "lint": "yarn makePrettier && yarn run eslint src/js/**",
     "makeBundle": "yarn run rollup -c",
     "makePrettier": "yarn run prettier --write \"src/**/*.js\"",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,4 @@
+import cleanOnce from './build/rollup-plugin-clean-once.mjs';
 import staticFiles from './build/rollup-plugin-static-files.mjs';
 
 export default [
@@ -12,7 +13,8 @@ export default [
         }, {
             file: 'dist/firefox/contentWA.js',
             format: 'iife'
-        }]
+        }],
+        plugins: [cleanOnce()],
     },
     {
         input: 'src/js/detectMSGRMeta.js',


### PR DESCRIPTION
**NOTE:** This depends on PR #187, which should ideally be merged first and have its branch deleted so that this one merges directly onto `main`, and we get separate commits on main for each PR.

## Prelude
Recent development on this codebase has made me  **really** want some sort of watch functionality that can re-bundle as soon as a relevant file changes. Luckily Rollup has that functionality, and we'll just need to merge other build commands, like copying files, formatting and linting, over to rollup, which should be fine since rollup was designed to have a plugin system that allows for intermediate custom steps in the build process.

## This PR
This PR moves another file operation to rollup: it adds a custom plugin to delete output directories **once** (so they don't get removed multiple times when running watch and for other rollup entry configs that might use the same plugin). Like the last PR, it has the added benefit of making the file operations platform agnostic and therefore able to run on non-POSIX environments (i.e. windows cmd or powershell).


## Test Plan

1. Ran `yarn build-local-dev`
2. Added a bunch of dummy files to `dir/chrome`
3. Re-ran `yarn build-local-dev` and ensured `dist/chrome` didn't have my dummy files.