### PR TITLE
Create rollup plugin to watch static files

### DIFF
--- a/build/rollup-plugin-prettier-build-start.mjs
+++ b/build/rollup-plugin-prettier-build-start.mjs
@@ -27,13 +27,13 @@ export default function rollupPrettierBuildStartPlugin(files) {
       }
       console.log('Running prettier for', Array.from(filesToFormat).join(' '));
       await genExec(
-        `yarn run prettier ${Array.from(filesToFormat).join(' ')} --write`,
+        `yarn run prettier ${Array.from(filesToFormat).join(' ')} --write`
       );
       filesToFormat.clear();
     },
 
     watchChange(_id, _change) {
       filesToFormat.add(files);
-    }
+    },
   };
 }

--- a/build/rollup-plugin-static-files.mjs
+++ b/build/rollup-plugin-static-files.mjs
@@ -2,24 +2,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as process from 'process';
 
-async function readDirRecursive(dirPath) {
-  const fileNames = await fs.readdir(dirPath);
-  const files = [];
-  await Promise.all(
-    fileNames.map(async fileName => {
-      const stats = await fs.stat(path.resolve(dirPath, fileName));
-      if (stats.isDirectory()) {
-        files.push(
-          ...(await readDirRecursive(path.resolve(dirPath, fileName)))
-        );
-      } else {
-        files.push(path.resolve(dirPath, fileName));
-        return Promise.resolve();
-      }
-    })
-  );
-  return files;
-}
+import { readDirRecursive } from './utils';
 
 const DEFAULT_OPTIONS = {
   keepDir: false,

--- a/build/rollup-plugin-watch-additional.mjs
+++ b/build/rollup-plugin-watch-additional.mjs
@@ -1,0 +1,24 @@
+import * as path from 'path';
+import * as process from 'process';
+
+import { readDirRecursive } from './utils';
+
+export default function rollupPluginWatch(dirs) {
+  return {
+    name: 'rollup-plugin-watch-additional',
+
+    async buildStart(_options) {
+      const rootDir = process.cwd();
+      await Promise.all(
+        dirs.map(async dir => {
+          const watchFilePaths = await readDirRecursive(
+            path.resolve(rootDir, dir)
+          );
+          for (const filePath of watchFilePaths) {
+            this.addWatchFile(filePath);
+          }
+        })
+      );
+    },
+  };
+}

--- a/build/utils.mjs
+++ b/build/utils.mjs
@@ -1,0 +1,27 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+
+/**
+ * Recursively get all files inside a directory
+ *
+ * @param {string} dirPath path to directory
+ * @returns {Array<string>}
+ */
+export async function readDirRecursive(dirPath) {
+  const fileNames = await fs.readdir(dirPath);
+  const files = [];
+  await Promise.all(
+    fileNames.map(async fileName => {
+      const stats = await fs.stat(path.resolve(dirPath, fileName));
+      if (stats.isDirectory()) {
+        files.push(
+          ...(await readDirRecursive(path.resolve(dirPath, fileName)))
+        );
+      } else {
+        files.push(path.resolve(dirPath, fileName));
+        return Promise.resolve();
+      }
+    })
+  );
+  return files;
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "build-local-dev": "yarn makeBundle",
+    "watch": "yarn run rollup --config --watch",
     "lint": "yarn makePrettier && yarn run eslint src/js/**",
     "makeBundle": "yarn run rollup -c",
     "makePrettier": "yarn run prettier --write \"src/**/*.js\" \"build/**/*.mjs\"",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,11 +2,11 @@ import cleanOnce from './build/rollup-plugin-clean-once.mjs';
 import eslintPlugin from '@rollup/plugin-eslint';
 import prettierBuildStart from './build/rollup-plugin-prettier-build-start.mjs';
 import staticFiles from './build/rollup-plugin-static-files.mjs';
+import watch from './build/rollup-plugin-watch-additional.mjs';
 
 function eslint() {
     return eslintPlugin({throwOnError: true});
 }
-
 function prettierSrc() {
     return prettierBuildStart('"src/**/*.js"');
 }
@@ -88,7 +88,7 @@ export default [
             eslint(),
             staticFiles(['images/', 'src/css/', 'src/html/']),
             staticFiles('_locales/', {keepDir: true}),
+            watch(['images/', 'src/css/', 'src/html/', '_locales/', 'config/']),
         ],
     }
-
 ];


### PR DESCRIPTION
**NOTE:** This depends on PR #189 which should ideally be merged first and have its branch deleted so that this one merges directly onto `main`, and we get separate commits on main for each PR.

## Prelude
Recent development on this codebase has made me  **really** want some sort of watch functionality that can re-bundle as soon as a relevant file changes. Luckily Rollup has that functionality, and we'll just need to merge other build commands, like copying files, formatting and linting, over to rollup, which should be fine since rollup was designed to have a plugin system that allows for intermediate custom steps in the build process.

## This PR
This adds in a custom rollup plugin to watch for changes in static files in certain folders. Why not re-use the custom static files plugin I created in #187 to watch the files that I copied? Because I'm also using that plugin as an [output plugin](https://rollupjs.org/guide/en/#using-output-plugins) that doesn't have the ability to mark files to watch, hence another plugin 😕.

## Test Plan
1. Ran `yarn watch` and ensured each platform was bundled correctly.
2. Made a change to an assets (e.g. config/v2/manifest.json) file and ensured rollup re-bundled the extension with the changes
3. Made a bunch of changes to source files and ensured rollup re-bundled the extension, formatted the source code, and ran eslint (and stopped the re-build if there was a lint error).