### PR TITLE
Remove /donate RegExp from excluded pathnames

### DIFF
--- a/src/js/detectFBMeta.js
+++ b/src/js/detectFBMeta.js
@@ -50,11 +50,6 @@ const EXCLUDED_PATHNAMES = [
    * Marketplace
    */
   '/marketplace/you/sales/confirm_identity/',
-
-  /**
-   * Fundraisers
-   */
-  /\/donate\/.*$/,
 ];
 
 startFor(ORIGIN_TYPE.FACEBOOK, EXCLUDED_PATHNAMES);


### PR DESCRIPTION
Nothing appears to be wrong with this route, and an endpoint like `/donate/<ID>` is susceptible to 404 redirects, meaning the 404 page would get ignored by the extension, which is not what we want.