### PR TITLE
Exclude the page plugin from triggering the extension

### DIFF
--- a/src/js/detectFBMeta.ts
+++ b/src/js/detectFBMeta.ts
@@ -42,6 +42,12 @@ const EXCLUDED_PATHNAMES: Array<string | RegExp> = [
   /\/v[\d.]+\/plugins\/like.php\/.*$/,
 
   /**
+   * Page embed plugin
+   */
+  // e.g. /v2.5/plugins/page.php
+  /\/v[\d.]+\/plugins\/page.php\/.*$/,
+
+  /**
    * Help center articles
    */
   /\/help\/.*$/,


### PR DESCRIPTION
This prevents that extension's content script from running on iframes containing the page plugin (example site with plugin:  https://www.chinadiscovery.com/chinese-visa/144-hour-visa-free.html)