### PR TITLE
Prevent disabling extension on first party sites

### DIFF
--- a/config/v2/manifest.json
+++ b/config/v2/manifest.json
@@ -49,9 +49,11 @@
         }
     ],
     "permissions": [
-        "https://*.privacy-auditability.cloudflare.com/",
-        "https://web.whatsapp.com/",
         "webRequest",
-        "https://static.xx.fbcdn.net/"
+        "https://*.privacy-auditability.cloudflare.com/",
+        "https://static.xx.fbcdn.net/",
+        "*://*.messenger.com/*",
+        "*://*.facebook.com/*",
+        "*://*.whatsapp.com/*"
     ]
 }

--- a/config/v3/manifest.json
+++ b/config/v3/manifest.json
@@ -52,6 +52,8 @@
     ],
     "host_permissions": [
         "https://*.privacy-auditability.cloudflare.com/",
-        "https://web.whatsapp.com/"
+        "*://*.messenger.com/*",
+        "*://*.facebook.com/*",
+        "*://*.whatsapp.com/*"
     ]
 }

--- a/src/js/detectFBMeta.ts
+++ b/src/js/detectFBMeta.ts
@@ -13,29 +13,6 @@ import { startFor } from './contentUtils.js';
 // NOTE: All pathnames checked against this list will be surrounded by '/'
 const EXCLUDED_PATHNAMES: Array<string | RegExp> = [
   /**
-   * Settings
-   */
-  '/settings/',
-  /\/[^/]+?\/settings\/$/, // Page settings
-
-  /**
-   * Games
-   */
-  '/games/',
-  // Anything in the /games pathname except /games/instantgames/
-  /\/games\/(?:(?!instantgames\/)).*$/,
-  '/gaming/games/',
-  // Anything in the /gaming/games pathname except /gaming/games/instantgames/
-  /\/gaming\/games\/(?:(?!instantgames\/)).*$/,
-
-  /**
-   * Share plugin
-   */
-  '/sharer.php/',
-  '/sharer/',
-  /\/sharer\/sharer.php.*$/,
-
-  /**
    * Like plugin
    */
   // e.g. /v2.5/plugins/like.php
@@ -51,11 +28,6 @@ const EXCLUDED_PATHNAMES: Array<string | RegExp> = [
    * Help center articles
    */
   /\/help\/.*$/,
-
-  /**
-   * Marketplace
-   */
-  '/marketplace/you/sales/confirm_identity/',
 ];
 
 startFor(ORIGIN_TYPE.FACEBOOK, EXCLUDED_PATHNAMES);

--- a/src/js/detectFBMeta.ts
+++ b/src/js/detectFBMeta.ts
@@ -23,11 +23,6 @@ const EXCLUDED_PATHNAMES: Array<string | RegExp> = [
    */
   // e.g. /v2.5/plugins/page.php
   /\/v[\d.]+\/plugins\/page.php\/.*$/,
-
-  /**
-   * Help center articles
-   */
-  /\/help\/.*$/,
 ];
 
 startFor(ORIGIN_TYPE.FACEBOOK, EXCLUDED_PATHNAMES);


### PR DESCRIPTION
- Extension will still be disabled for any external sites that have Facebook plugins which embed iframes (e.g. https://www.chinadiscovery.com/chinese-visa/144-hour-visa-free.html)
- All first party pages, and Facebook plugins in first party sites are no longer allowed to disable the extension, and will be marked as invalid whenever a content script from a frame attempts to disable the extension for the tab