### PR TITLE
Add checks for CSP enforcement

### DIFF
--- a/config/v2/manifest.json
+++ b/config/v2/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "Code Verify",
-    "version": "2.0.1",
+    "version": "2.1.1",
     "default_locale": "en",
     "description": "An extension to verify the code running in your browser matches what was published.",
     "page_action": {

--- a/config/v3/manifest.json
+++ b/config/v3/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Code Verify",
-    "version": "2.0.1",
+    "version": "2.1.1",
     "default_locale": "en",
     "description": "An extension to verify the code running in your browser matches what was published.",
     "action": {

--- a/src/js/contentUtils.js
+++ b/src/js/contentUtils.js
@@ -561,6 +561,102 @@ export function hasInvalidScripts(scriptNodeMaybe, scriptList) {
   return;
 }
 
+const parseCSPString = csp => {
+  const directiveStrings = csp.split(';');
+  return directiveStrings.reduce((map, directiveString) => {
+    const directive = directiveString.substring(
+      0,
+      directiveString.indexOf(' ')
+    );
+    const values = directiveString
+      .substring(directiveString.indexOf(' '))
+      .split(' ');
+    return map.set(directive, new Set(values));
+  }, new Map());
+};
+
+const checkCSPHeaders = (cspHeader, cspReportHeader) => {
+  // If CSP is enforcing on evals we don't need to do extra checks
+  if (cspHeader != null) {
+    const cspMap = parseCSPString(cspHeader);
+    if (cspMap.has('script-src')) {
+      if (!cspMap.get('script-src').has("'unsafe-eval'")) {
+        return;
+      }
+    }
+    if (!cspMap.has('script-src') && cspMap.has('default-src')) {
+      if (!cspMap.get('default-src').has("'unsafe-eval'")) {
+        return;
+      }
+    }
+  }
+
+  // If CSP is not reporting on evals we cannot catch them
+  if (cspReportHeader != null) {
+    const cspReportMap = parseCSPString(cspReportHeader);
+    if (cspReportMap.has('script-src')) {
+      if (cspReportMap.get('script-src').has("'unsafe-eval'")) {
+        updateCurrentState(STATES.INVALID);
+        return;
+      }
+    }
+    if (!cspReportMap.has('script-src') && cspReportMap.has('default-src')) {
+      if (cspReportMap.get('default-src').has("'unsafe-eval'")) {
+        updateCurrentState(STATES.INVALID);
+        return;
+      }
+    }
+  } else {
+    updateCurrentState(STATES.INVALID);
+    return;
+  }
+
+  // Check for evals
+  scanForCSPEvalReportViolations();
+};
+
+const scanForCSPEvalReportViolations = () => {
+  document.addEventListener('securitypolicyviolation', e => {
+    // Older Browser can't distinguish between 'eval' and 'wasm-eval' violations
+    // We need to check if there is an eval violation
+    if (e.blockedURI !== 'eval') {
+      return;
+    }
+
+    if (e.disposition === 'enforce') {
+      return;
+    }
+
+    fetch(e.sourceFile, { cache: 'only-if-cached', mode: 'same-origin' })
+      .then(response => {
+        if (response.status === 504) {
+          updateCurrentState(STATES.INVALID);
+        }
+
+        return response.text();
+      })
+      .then(code => {
+        const violatingLine = code.split(/\r?\n/)[e.lineNumber - 1];
+        if (
+          violatingLine.includes('WebAssembly') &&
+          !violatingLine.includes('eval(') &&
+          !violatingLine.includes('Function(') &&
+          !violatingLine.includes("setTimeout('") &&
+          !violatingLine.includes("setInterval('") &&
+          !violatingLine.includes('setTimeout("') &&
+          !violatingLine.includes('setInterval("')
+        ) {
+          return;
+        }
+        updateCurrentState(STATES.INVALID);
+        chrome.runtime.sendMessage({
+          type: MESSAGE_TYPE.DEBUG,
+          log: `Caught eval in ${e.sourceFile}`,
+        });
+      });
+  });
+};
+
 export const scanForScripts = () => {
   const allElements = document.getElementsByTagName('*');
 
@@ -851,10 +947,18 @@ function isPathnameExcluded(excludedPathnames) {
 }
 
 export function startFor(origin, excludedPathnames = []) {
-  chrome.runtime.sendMessage({
-    type: MESSAGE_TYPE.CONTENT_SCRIPT_START,
-    origin,
-  });
+  chrome.runtime
+    .sendMessage({
+      type: MESSAGE_TYPE.CONTENT_SCRIPT_START,
+      origin,
+    })
+    .then(resp => {
+      if (
+        [ORIGIN_TYPE.FACEBOOK, ORIGIN_TYPE.MESSENGER].includes(currentOrigin)
+      ) {
+        checkCSPHeaders(resp.cspHeader, resp.cspReportHeader);
+      }
+    });
   if (isPathnameExcluded(excludedPathnames)) {
     updateCurrentState(STATES.IGNORE);
     return;


### PR DESCRIPTION
We want to ensure that the CSP headers are blocking unsafe evals through enforcement.

When this is not possible we need to ensure that CSP headers are forcing reporting on unsafe-evals and we listen to the violation events and update CodeVerify's status accordingly.