### PR TITLE
Fix recursion new

### DIFF
--- a/src/js/__tests__/contentUtils-test.js
+++ b/src/js/__tests__/contentUtils-test.js
@@ -72,6 +72,7 @@ describe('contentUtils', () => {
       // no hasAttribute function
       let fakeElement = {
         childNodes: [],
+        tagName: 'tagName',
       };
       hasInvalidAttributes(fakeElement);
       expect(window.chrome.runtime.sendMessage.mock.calls.length).toBe(0);
@@ -82,6 +83,7 @@ describe('contentUtils', () => {
           return false;
         },
         childNodes: [],
+        tagName: 'tagName',
       };
       hasInvalidAttributes(fakeElement);
       expect(window.chrome.runtime.sendMessage.mock.calls.length).toBe(0);
@@ -97,6 +99,7 @@ describe('contentUtils', () => {
           return true;
         },
         childNodes: [],
+        tagName: 'div',
       };
       hasInvalidAttributes(fakeElement);
       expect(window.chrome.runtime.sendMessage.mock.calls.length).toBe(0);
@@ -112,6 +115,7 @@ describe('contentUtils', () => {
           return true;
         },
         childNodes: [],
+        tagName: 'div',
       };
       hasInvalidAttributes(fakeElement);
       expect(window.chrome.runtime.sendMessage.mock.calls.length).toBe(2);
@@ -129,6 +133,7 @@ describe('contentUtils', () => {
           return true;
         },
         nodeType: 2,
+        tagName: 'tagName',
       };
       hasInvalidScripts(fakeElement, []);
       expect(window.chrome.runtime.sendMessage.mock.calls.length).toBe(0);
@@ -143,6 +148,7 @@ describe('contentUtils', () => {
         childNodes: [],
         nodeName: 'SCRIPT',
         nodeType: 1,
+        tagName: 'div',
       };
       const scriptMap = new Map([['version', []]]);
       hasInvalidScripts(fakeElement, scriptMap);
@@ -167,6 +173,7 @@ describe('contentUtils', () => {
             },
             nodeType: 2,
             nodeName: 'nodename',
+            tagName: 'tagName',
           },
           {
             attributes: [
@@ -179,6 +186,7 @@ describe('contentUtils', () => {
             },
             nodeType: 3,
             nodeName: 'nodename',
+            tagName: 'tagName',
           },
         ],
         hasAttribute: () => {
@@ -208,6 +216,7 @@ describe('contentUtils', () => {
             nodeType: 2,
             nodeName: 'nodename',
             childNodes: [],
+            tagName: 'tagName',
           },
           {
             attributes: {
@@ -220,6 +229,7 @@ describe('contentUtils', () => {
             nodeName: 'SCRIPT',
             nodeType: 1,
             childNodes: [],
+            tagName: 'tagName',
           },
         ],
         hasAttribute: () => {
@@ -253,6 +263,7 @@ describe('contentUtils', () => {
             nodeType: 2,
             nodeName: 'nodename',
             childNodes: [],
+            tagName: 'tagName',
           },
           {
             attributes: {
@@ -281,6 +292,7 @@ describe('contentUtils', () => {
             nodeType: 1,
             nodeName: 'nodename',
             childNodes: [],
+            tagName: 'tagName',
           },
         ],
         hasAttribute: () => {

--- a/src/js/__tests__/contentUtils-test.js
+++ b/src/js/__tests__/contentUtils-test.js
@@ -270,28 +270,37 @@ describe('contentUtils', () => {
               'data-binary-transparency-hash-key': {value: 'green'},
               getAttribute: () => {},
             },
-            getElementsByTagName: () => {
-              return [
-                {
-                  attributes: {
-                    'data-binary-transparency-hash-key': {value: 'green1'},
-                  },
-                  getAttribute: () => {},
+            childNodes: [
+              {
+                attributes: {
+                  'data-binary-transparency-hash-key': {value: 'green1'},
                 },
-                {
-                  attributes: {
-                    'data-binary-transparency-hash-key': {value: 'green2'},
-                  },
-                  getAttribute: () => {},
+                nodeName: 'script',
+                nodeType: 1,
+                getAttribute: () => {},
+                hasAttribute: () => {
+                  return false;
                 },
-              ];
-            },
+                tagName: 'tagName',
+              },
+              {
+                attributes: {
+                  'data-binary-transparency-hash-key': {value: 'green2'},
+                },
+                getAttribute: () => {},
+                hasAttribute: () => {
+                  return false;
+                },
+                nodeName: 'script',
+                nodeType: 1,
+                tagName: 'tagName',
+              },
+            ],
             hasAttribute: () => {
               return false;
             },
             nodeType: 1,
             nodeName: 'nodename',
-            childNodes: [],
             tagName: 'tagName',
           },
         ],

--- a/src/js/contentUtils.js
+++ b/src/js/contentUtils.js
@@ -313,7 +313,7 @@ export function hasInvalidScripts(scriptNodeMaybe, scriptList) {
     storeFoundJS(scriptNodeMaybe, scriptList);
   } else if (scriptNodeMaybe.childNodes.length > 0) {
     scriptNodeMaybe.childNodes.forEach(childNode => {
-      hasInvalidScripts(childNode);
+      hasInvalidScripts(childNode, scriptList);
     });
   }
 }

--- a/src/js/contentUtils.js
+++ b/src/js/contentUtils.js
@@ -304,33 +304,18 @@ function checkNodeForViolations(element) {
 export function hasInvalidScripts(scriptNodeMaybe, scriptList) {
   // if not an HTMLElement ignore it!
   if (scriptNodeMaybe.nodeType !== 1) {
-    return false;
+    return;
   }
+
   checkNodeForViolations(scriptNodeMaybe);
 
   if (scriptNodeMaybe.nodeName.toLowerCase() === 'script') {
-    return storeFoundJS(scriptNodeMaybe, scriptList);
+    storeFoundJS(scriptNodeMaybe, scriptList);
   } else if (scriptNodeMaybe.childNodes.length > 0) {
     scriptNodeMaybe.childNodes.forEach(childNode => {
-      // if not an HTMLElement ignore it!
-      if (childNode.nodeType !== 1) {
-        return;
-      }
-      checkNodeForViolations(childNode);
-      if (childNode.nodeName.toLowerCase() === 'script') {
-        storeFoundJS(childNode, scriptList);
-        return;
-      }
-
-      Array.from(childNode.getElementsByTagName('script')).forEach(
-        childScript => {
-          storeFoundJS(childScript, scriptList);
-        },
-      );
+      hasInvalidScripts(childNode);
     });
   }
-
-  return;
 }
 
 export const scanForScripts = () => {

--- a/src/js/contentUtils.js
+++ b/src/js/contentUtils.js
@@ -219,7 +219,7 @@ const AttributeCheckPairs = [
   {nodeName: 'x', attributeName: 'xlink:href'},
 ];
 
-export function hasViolatingJavaScriptURI(htmlElement, checkChildren) {
+export function hasViolatingJavaScriptURI(htmlElement) {
   let checkURL = '';
   const lowerCaseNodeName = htmlElement.nodeName.toLowerCase();
   AttributeCheckPairs.forEach(checkPair => {
@@ -241,19 +241,13 @@ export function hasViolatingJavaScriptURI(htmlElement, checkChildren) {
       updateCurrentState(STATES.INVALID);
     }
   }
-
-  if (checkChildren && typeof htmlElement.childNodes !== 'undefined') {
-    htmlElement.childNodes.forEach(element => {
-      hasViolatingJavaScriptURI(element, checkChildren);
-    });
-  }
 }
 
 function isEventHandlerAttribute(attribute) {
   return attribute.indexOf('on') === 0;
 }
 
-export function hasInvalidAttributes(htmlElement, checkChildren) {
+export function hasInvalidAttributes(htmlElement) {
   if (
     typeof htmlElement.attributes === 'object' &&
     Object.keys(htmlElement.attributes).length >= 1
@@ -273,45 +267,37 @@ export function hasInvalidAttributes(htmlElement, checkChildren) {
       }
     });
   }
-  // check child nodes as well, since a malicious attacker could try to inject an invalid attribute via an image node in a svg tag using a use element
-  if (checkChildren && htmlElement.childNodes.length > 0) {
-    htmlElement.childNodes.forEach(childNode => {
-      if (childNode.nodeType === 1) {
-        hasInvalidAttributes(childNode, checkChildren);
-      }
-      // if the element is a math element, check all the attributes of the child node to ensure that there are on href or xlink:href attributes with javascript urls
+  // if the element is a math element, check all the attributes of the child node to ensure that there are on href or xlink:href attributes with javascript urls
+  if (
+    htmlElement.tagName.toLowerCase() === 'math' &&
+    Object.keys(htmlElement.attributes).length >= 1
+  ) {
+    Array.from(htmlElement.attributes).forEach(elementAttribute => {
       if (
-        htmlElement.tagName.toLowerCase() === 'math' &&
-        Object.keys(childNode.attributes).length >= 1
+        (elementAttribute.localName === 'href' ||
+          elementAttribute.localName === 'xlink:href') &&
+        htmlElement
+          .getAttribute(elementAttribute.localName)
+          .toLowerCase()
+          .startsWith('javascript')
       ) {
-        Array.from(childNode.attributes).forEach(elementAttribute => {
-          if (
-            (elementAttribute.localName === 'href' ||
-              elementAttribute.localName === 'xlink:href') &&
-            childNode
-              .getAttribute(elementAttribute.localName)
-              .toLowerCase()
-              .startsWith('javascript')
-          ) {
-            chrome.runtime.sendMessage({
-              type: MESSAGE_TYPE.DEBUG,
-              log:
-                'violating attribute ' +
-                elementAttribute.localName +
-                ' from element ' +
-                htmlElement.outerHTML,
-            });
-            updateCurrentState(STATES.INVALID);
-          }
+        chrome.runtime.sendMessage({
+          type: MESSAGE_TYPE.DEBUG,
+          log:
+            'violating attribute ' +
+            elementAttribute.localName +
+            ' from element ' +
+            htmlElement.outerHTML,
         });
+        updateCurrentState(STATES.INVALID);
       }
     });
   }
 }
 
-function checkNodesForViolations(element, checkChildren = true) {
-  hasViolatingJavaScriptURI(element, checkChildren);
-  hasInvalidAttributes(element, checkChildren);
+function checkNodeForViolations(element) {
+  hasViolatingJavaScriptURI(element);
+  hasInvalidAttributes(element);
 }
 
 export function hasInvalidScripts(scriptNodeMaybe, scriptList) {
@@ -319,7 +305,7 @@ export function hasInvalidScripts(scriptNodeMaybe, scriptList) {
   if (scriptNodeMaybe.nodeType !== 1) {
     return false;
   }
-  checkNodesForViolations(scriptNodeMaybe);
+  checkNodeForViolations(scriptNodeMaybe);
 
   if (scriptNodeMaybe.nodeName.toLowerCase() === 'script') {
     return storeFoundJS(scriptNodeMaybe, scriptList);
@@ -329,7 +315,7 @@ export function hasInvalidScripts(scriptNodeMaybe, scriptList) {
       if (childNode.nodeType !== 1) {
         return;
       }
-      checkNodesForViolations(childNode);
+      checkNodeForViolations(childNode);
       if (childNode.nodeName.toLowerCase() === 'script') {
         storeFoundJS(childNode, scriptList);
         return;
@@ -350,7 +336,7 @@ export const scanForScripts = () => {
   const allElements = document.getElementsByTagName('*');
 
   Array.from(allElements).forEach(element => {
-    checkNodesForViolations(element);
+    checkNodeForViolations(element);
     // next check for existing script elements and if they're violating
     if (element.nodeName.toLowerCase() === 'script') {
       storeFoundJS(element, foundScripts);
@@ -367,7 +353,7 @@ export const scanForScripts = () => {
           });
         } else if (
           mutation.type === 'attributes' &&
-          checkNodesForViolations(mutation.target, false)
+          checkNodeForViolations(mutation.target, false)
         ) {
           updateCurrentState(STATES.INVALID);
           chrome.runtime.sendMessage({

--- a/src/js/contentUtils.js
+++ b/src/js/contentUtils.js
@@ -268,6 +268,7 @@ export function hasInvalidAttributes(htmlElement) {
     });
   }
   // if the element is a math element, check all the attributes of the child node to ensure that there are on href or xlink:href attributes with javascript urls
+
   if (
     htmlElement.tagName.toLowerCase() === 'math' &&
     Object.keys(htmlElement.attributes).length >= 1


### PR DESCRIPTION
Recursion code was messy and visiting nodes more than needed. This set of changes centralizes the recursion logic in one place.


Flow:

1. Script mounts, `document.getElementsByTagName('*')` fetches all nodes and all nodes are verified via `checkNodeForViolations` , scripts are also stored as necessary via `storeFoundJS`
2. MutationObserver detects additions/changes
  a.  Listen to added childNodes, call `hasInvalidScripts` on each node.
  b.  Listen to changed attributes and call `checkNodeForViolations` on affected node

All the recursion happens in `hasInvalidScripts`. Recursion is necessary since the MutationObserver only detects top level added nodes but we need to check their children.

```
export function hasInvalidScripts(scriptNodeMaybe, scriptList) {
  // if not an HTMLElement ignore it!
  if (scriptNodeMaybe.nodeType !== 1) {
    return;
  }

  checkNodeForViolations(scriptNodeMaybe);

  if (scriptNodeMaybe.nodeName.toLowerCase() === 'script') {
    storeFoundJS(scriptNodeMaybe, scriptList);
  } else if (scriptNodeMaybe.childNodes.length > 0) {
    scriptNodeMaybe.childNodes.forEach(childNode => {
      hasInvalidScripts(childNode, scriptList);
    });
  }
}
```