### PR TITLE
Avoid throwing unnecessary errors when listening to uncached scripts

### DIFF
--- a/src/js/background/setupNoCacheListeners.ts
+++ b/src/js/background/setupNoCacheListeners.ts
@@ -12,8 +12,8 @@ export default function setupNoCacheListeners(
     response => {
       if (
         response.tabId !== -1 &&
-        cachedScriptsUrls.get(response.tabId).has(response.url) &&
-        !response.fromCache
+        !response.fromCache &&
+        cachedScriptsUrls.get(response.tabId).has(response.url)
       ) {
         console.log(`Detected uncached script ${response.url}`);
         chrome.tabs.query({active: true, currentWindow: true}, function (tabs) {

--- a/src/js/background/setupNoCacheListeners.ts
+++ b/src/js/background/setupNoCacheListeners.ts
@@ -11,6 +11,7 @@ export default function setupNoCacheListeners(
   chrome.webRequest.onResponseStarted.addListener(
     response => {
       if (
+        response.tabId !== -1 &&
         cachedScriptsUrls.get(response.tabId).has(response.url) &&
         !response.fromCache
       ) {


### PR DESCRIPTION
Was spewing a bunch of unnecessary errors here by catching requests from other extensions, we only care about the case where the `tabId` is set in the first place.