### PR TITLE
Further improve TS coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "yarn lint && node --experimental-vm-modules --no-warnings node_modules/jest/bin/jest.js"
   },
   "devDependencies": {
-    "@rollup/plugin-eslint": "^8.0.2",
+    "@rollup/plugin-eslint": "^9.0.3",
     "@rollup/plugin-typescript": "^11.0.0",
     "@types/chrome": "^0.0.213",
     "@types/jest": "^29.4.0",

--- a/src/js/background.ts
+++ b/src/js/background.ts
@@ -22,13 +22,13 @@ import setupNoCacheListeners from './background/setupNoCacheListeners';
 import {validateMetaCompanyManifest} from './background/validateMetaCompanyManifest';
 import {validateManifest} from './background/validateManifest';
 
-const manifestCache = new Map<Origin, Map<string, Manifest>>();
-const cspHeaders = new Map<number, string | undefined>();
-const cspReportHeaders = new Map<number, string | undefined>();
+const MANIFEST_CACHE = new Map<Origin, Map<string, Manifest>>();
+const CSP_HEADERS = new Map<number, string | undefined>();
+const CSP_REPORT_HEADERS = new Map<number, string | undefined>();
 
 // Keeps track of scripts `fetch`-ed by the extension to ensure they are all
 // resolved from browser cache
-const cachedScriptsUrls = new Map<number, Set<string>>();
+const CACHED_SCRIPTS_URLS = new Map<number, Set<string>>();
 
 type Manifest = {
   root: string;
@@ -68,10 +68,10 @@ function handleMessages(
       ).then(valid => {
         console.log('result is ', valid);
         if (valid) {
-          let origin = manifestCache.get(message.origin);
+          let origin = MANIFEST_CACHE.get(message.origin);
           if (origin == null) {
             origin = new Map();
-            manifestCache.set(message.origin, origin);
+            MANIFEST_CACHE.set(message.origin, origin);
           }
           // roll through the existing manifests and remove expired ones
           if (ORIGIN_TIMEOUT[message.origin] > 0) {
@@ -115,10 +115,10 @@ function handleMessages(
       ).then(validationResult => {
         if (validationResult.valid) {
           // store manifest to subsequently validate JS
-          let origin = manifestCache.get(message.origin);
+          let origin = MANIFEST_CACHE.get(message.origin);
           if (origin == null) {
             origin = new Map();
-            manifestCache.set(message.origin, origin);
+            MANIFEST_CACHE.set(message.origin, origin);
           }
           // roll through the existing manifests and remove expired ones
           if (ORIGIN_TIMEOUT[message.origin] > 0) {
@@ -142,7 +142,7 @@ function handleMessages(
     }
     return true;
   } else if (message.type == MESSAGE_TYPE.RAW_JS) {
-    const origin = manifestCache.get(message.origin);
+    const origin = MANIFEST_CACHE.get(message.origin);
     if (!origin) {
       addDebugLog(
         sender.tab.id,
@@ -215,14 +215,14 @@ function handleMessages(
     recordContentScriptStart(sender, message.origin);
     sendResponse({
       success: true,
-      cspHeader: cspHeaders.get(sender.tab.id),
-      cspReportHeader: cspReportHeaders.get(sender.tab.id),
+      cspHeader: CSP_HEADERS.get(sender.tab.id),
+      cspReportHeader: CSP_REPORT_HEADERS.get(sender.tab.id),
     });
   } else if (message.type === MESSAGE_TYPE.UPDATED_CACHED_SCRIPT_URLS) {
-    if (!cachedScriptsUrls.has(sender.tab.id)) {
-      cachedScriptsUrls.set(sender.tab.id, new Set());
+    if (!CACHED_SCRIPTS_URLS.has(sender.tab.id)) {
+      CACHED_SCRIPTS_URLS.set(sender.tab.id, new Set());
     }
-    cachedScriptsUrls.get(sender.tab.id).add(message.url);
+    CACHED_SCRIPTS_URLS.get(sender.tab.id).add(message.url);
     sendResponse({success: true});
     return true;
   }
@@ -230,8 +230,8 @@ function handleMessages(
 
 chrome.runtime.onMessage.addListener(handleMessages);
 
-setupCSPListener(cspHeaders, cspReportHeaders);
-setupNoCacheListeners(cachedScriptsUrls);
+setupCSPListener(CSP_HEADERS, CSP_REPORT_HEADERS);
+setupNoCacheListeners(CACHED_SCRIPTS_URLS);
 setupDebugLogListener();
 
 // Emulate PageActions

--- a/src/js/background.ts
+++ b/src/js/background.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type {Origin, State} from './config';
+import type {Origin} from './config';
 import {MESSAGE_TYPE, ORIGIN_HOST, ORIGIN_TIMEOUT} from './config';
 
 import {
@@ -22,6 +22,7 @@ import setupNoCacheListeners from './background/setupNoCacheListeners';
 import {validateMetaCompanyManifest} from './background/validateMetaCompanyManifest';
 import {validateManifest} from './background/validateManifest';
 import isFbOrMsgrOrigin from './shared/isFbOrMsgrOrigin';
+import {MessagePayload} from './shared/MessagePayload';
 
 const MANIFEST_CACHE = new Map<Origin, Map<string, Manifest>>();
 const CSP_HEADERS = new Map<number, string | undefined>();
@@ -36,47 +37,6 @@ type Manifest = {
   start: number;
   leaves: Array<string>;
 };
-type MessagePayload =
-  | {
-      type: typeof MESSAGE_TYPE.LOAD_MANIFEST;
-      origin: Origin;
-      rootHash: string;
-      otherHashes: {
-        combined_hash: string;
-        longtail: string;
-        main: string;
-      };
-      leaves: Array<string>;
-      version: string;
-      workaround: string;
-    }
-  | {
-      type: typeof MESSAGE_TYPE.RAW_JS;
-      rawjs: string;
-      origin: Origin;
-      version: string;
-    }
-  | {
-      type: typeof MESSAGE_TYPE.DEBUG;
-      log: string;
-    }
-  | {
-      type: typeof MESSAGE_TYPE.GET_DEBUG;
-      tabId: number;
-    }
-  | {
-      type: typeof MESSAGE_TYPE.UPDATE_STATE;
-      state: State;
-      origin: Origin;
-    }
-  | {
-      type: typeof MESSAGE_TYPE.CONTENT_SCRIPT_START;
-      origin: Origin;
-    }
-  | {
-      type: typeof MESSAGE_TYPE.UPDATED_CACHED_SCRIPT_URLS;
-      url: string;
-    };
 
 type Response = {
   valid?: boolean;

--- a/src/js/background.ts
+++ b/src/js/background.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type {MessageType, Origin} from './config';
-import {MESSAGE_TYPE, ORIGIN_HOST, ORIGIN_TIMEOUT, ORIGIN_TYPE} from './config';
+import type {Origin, State} from './config';
+import {MESSAGE_TYPE, ORIGIN_HOST, ORIGIN_TIMEOUT} from './config';
 
 import {
   recordContentScriptStart,
@@ -21,6 +21,7 @@ import setupCSPListener from './background/setupCSPListener';
 import setupNoCacheListeners from './background/setupNoCacheListeners';
 import {validateMetaCompanyManifest} from './background/validateMetaCompanyManifest';
 import {validateManifest} from './background/validateManifest';
+import isFbOrMsgrOrigin from './shared/isFbOrMsgrOrigin';
 
 const MANIFEST_CACHE = new Map<Origin, Map<string, Manifest>>();
 const CSP_HEADERS = new Map<number, string | undefined>();
@@ -35,10 +36,48 @@ type Manifest = {
   start: number;
   leaves: Array<string>;
 };
-type MessagePayload = {
-  type: MessageType;
-  [key: string]: any;
-};
+type MessagePayload =
+  | {
+      type: typeof MESSAGE_TYPE.LOAD_MANIFEST;
+      origin: Origin;
+      rootHash: string;
+      otherHashes: {
+        combined_hash: string;
+        longtail: string;
+        main: string;
+      };
+      leaves: Array<string>;
+      version: string;
+      workaround: string;
+    }
+  | {
+      type: typeof MESSAGE_TYPE.RAW_JS;
+      rawjs: string;
+      origin: Origin;
+      version: string;
+    }
+  | {
+      type: typeof MESSAGE_TYPE.DEBUG;
+      log: string;
+    }
+  | {
+      type: typeof MESSAGE_TYPE.GET_DEBUG;
+      tabId: number;
+    }
+  | {
+      type: typeof MESSAGE_TYPE.UPDATE_STATE;
+      state: State;
+      origin: Origin;
+    }
+  | {
+      type: typeof MESSAGE_TYPE.CONTENT_SCRIPT_START;
+      origin: Origin;
+    }
+  | {
+      type: typeof MESSAGE_TYPE.UPDATED_CACHED_SCRIPT_URLS;
+      url: string;
+    };
+
 type Response = {
   valid?: boolean;
   success?: boolean;
@@ -58,9 +97,7 @@ function handleMessages(
 
   if (message.type == MESSAGE_TYPE.LOAD_MANIFEST) {
     // validate manifest
-    if (
-      [ORIGIN_TYPE.FACEBOOK, ORIGIN_TYPE.MESSENGER].includes(message.origin)
-    ) {
+    if (isFbOrMsgrOrigin(message.origin)) {
       validateMetaCompanyManifest(
         message.rootHash,
         message.otherHashes,

--- a/src/js/content/checkCSPHeaders.ts
+++ b/src/js/content/checkCSPHeaders.ts
@@ -55,7 +55,7 @@ function scanForCSPEvalReportViolations(): void {
   });
 }
 
-export function checkCSPHeaders(
+export default function checkCSPHeaders(
   cspHeader: string | undefined,
   cspReportHeader: string | undefined,
 ) {

--- a/src/js/content/checkElementForViolatingAttributes.ts
+++ b/src/js/content/checkElementForViolatingAttributes.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {MESSAGE_TYPE, STATES} from '../config';
+import {updateCurrentState} from './updateCurrentState';
+
+function isEventHandlerAttribute(attribute: string): boolean {
+  return attribute.indexOf('on') === 0;
+}
+
+export default function checkElementForViolatingAttributes(
+  element: Element,
+): void {
+  if (
+    typeof element.attributes === 'object' &&
+    Object.keys(element.attributes).length >= 1
+  ) {
+    Array.from(element.attributes).forEach(elementAttribute => {
+      // check first for violating attributes
+      if (isEventHandlerAttribute(elementAttribute.localName)) {
+        chrome.runtime.sendMessage({
+          type: MESSAGE_TYPE.DEBUG,
+          log:
+            'violating attribute ' +
+            elementAttribute.localName +
+            ' from element ' +
+            element.outerHTML,
+        });
+        updateCurrentState(STATES.INVALID);
+      }
+    });
+  }
+  // if the element is a math element, check all the attributes of the child node to ensure that there are on href or xlink:href attributes with javascript urls
+
+  if (
+    element.tagName.toLowerCase() === 'math' &&
+    Object.keys(element.attributes).length >= 1
+  ) {
+    Array.from(element.attributes).forEach(elementAttribute => {
+      if (
+        (elementAttribute.localName === 'href' ||
+          elementAttribute.localName === 'xlink:href') &&
+        element
+          .getAttribute(elementAttribute.localName)
+          .toLowerCase()
+          .startsWith('javascript')
+      ) {
+        chrome.runtime.sendMessage({
+          type: MESSAGE_TYPE.DEBUG,
+          log:
+            'violating attribute ' +
+            elementAttribute.localName +
+            ' from element ' +
+            element.outerHTML,
+        });
+        updateCurrentState(STATES.INVALID);
+      }
+    });
+  }
+}

--- a/src/js/content/checkElementForViolatingAttributes.ts
+++ b/src/js/content/checkElementForViolatingAttributes.ts
@@ -12,9 +12,7 @@ function isEventHandlerAttribute(attribute: string): boolean {
   return attribute.indexOf('on') === 0;
 }
 
-export default function checkElementForViolatingAttributes(
-  element: Element,
-): void {
+export function checkElementForViolatingAttributes(element: Element): void {
   if (
     typeof element.attributes === 'object' &&
     Object.keys(element.attributes).length >= 1

--- a/src/js/content/checkElementForViolatingJSUri.ts
+++ b/src/js/content/checkElementForViolatingJSUri.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {MESSAGE_TYPE, STATES} from '../config';
+import {updateCurrentState} from './updateCurrentState';
+
+function getAttributeValue(
+  nodeName: string,
+  elementName: string,
+  element: Element,
+  attributeName: string,
+  currentAttributeValue: string,
+): string {
+  if (
+    nodeName.toLowerCase() === elementName &&
+    element.hasAttribute(attributeName)
+  ) {
+    return element.getAttribute(attributeName).toLowerCase();
+  }
+  return currentAttributeValue;
+}
+
+const AttributeCheckPairs = [
+  {elementName: 'a', attributeName: 'href'},
+  {elementName: 'iframe', attributeName: 'src'},
+  {elementName: 'iframe', attributeName: 'srcdoc'},
+  {elementName: 'form', attributeName: 'action'},
+  {elementName: 'input', attributeName: 'formaction'},
+  {elementName: 'button', attributeName: 'formaction'},
+  {elementName: 'a', attributeName: 'xlink:href'},
+  {elementName: 'ncc', attributeName: 'href'},
+  {elementName: 'embed', attributeName: 'src'},
+  {elementName: 'object', attributeName: 'data'},
+  {elementName: 'animate', attributeName: 'xlink:href'},
+  {elementName: 'script', attributeName: 'xlink:href'},
+  {elementName: 'use', attributeName: 'href'},
+  {elementName: 'use', attributeName: 'xlink:href'},
+  {elementName: 'x', attributeName: 'href'},
+  {elementName: 'x', attributeName: 'xlink:href'},
+];
+
+export default function checkElementForViolatingJSUri(element: Element): void {
+  let checkURL = '';
+  const lowerCaseNodeName = element.nodeName.toLowerCase();
+  AttributeCheckPairs.forEach(checkPair => {
+    checkURL = getAttributeValue(
+      lowerCaseNodeName,
+      checkPair.elementName,
+      element,
+      checkPair.attributeName,
+      checkURL,
+    );
+  });
+  if (checkURL !== '') {
+    // make sure anchor tags and object tags don't have javascript urls
+    if (checkURL.indexOf('javascript') >= 0) {
+      chrome.runtime.sendMessage({
+        type: MESSAGE_TYPE.DEBUG,
+        log: 'violating attribute: javascript url',
+      });
+      updateCurrentState(STATES.INVALID);
+    }
+  }
+}

--- a/src/js/content/checkElementForViolatingJSUri.ts
+++ b/src/js/content/checkElementForViolatingJSUri.ts
@@ -43,7 +43,7 @@ const AttributeCheckPairs = [
   {elementName: 'x', attributeName: 'xlink:href'},
 ];
 
-export default function checkElementForViolatingJSUri(element: Element): void {
+export default function checkElementForViolatingJSURI(element: Element): void {
   let checkURL = '';
   const lowerCaseNodeName = element.nodeName.toLowerCase();
   AttributeCheckPairs.forEach(checkPair => {

--- a/src/js/content/checkElementForViolatingJSUri.ts
+++ b/src/js/content/checkElementForViolatingJSUri.ts
@@ -43,7 +43,7 @@ const AttributeCheckPairs = [
   {elementName: 'x', attributeName: 'xlink:href'},
 ];
 
-export default function checkElementForViolatingJSURI(element: Element): void {
+export default function checkElementForViolatingJSUri(element: Element): void {
   let checkURL = '';
   const lowerCaseNodeName = element.nodeName.toLowerCase();
   AttributeCheckPairs.forEach(checkPair => {

--- a/src/js/content/downloadJSArchive.ts
+++ b/src/js/content/downloadJSArchive.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export async function downloadJSArchive(
+export default async function downloadJSArchive(
   sourceScripts: Map<string, ReadableStream>,
   inlineScripts: Array<Map<string, string>>,
 ): Promise<void> {

--- a/src/js/content/updateCurrentState.ts
+++ b/src/js/content/updateCurrentState.ts
@@ -5,9 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {MESSAGE_TYPE, State} from '../config';
+import {MESSAGE_TYPE, Origin, State} from '../config';
 
-export const currentOrigin = {val: ''};
+export const currentOrigin: {val: string | Origin} = {val: ''};
 
 export function updateCurrentState(state: State) {
   chrome.runtime.sendMessage({

--- a/src/js/contentUtils.ts
+++ b/src/js/contentUtils.ts
@@ -20,13 +20,13 @@ import downloadJSArchive from './content/downloadJSArchive';
 import alertBackgroundOfImminentFetch from './content/alertBackgroundOfImminentFetch';
 import {currentOrigin, updateCurrentState} from './content/updateCurrentState';
 import checkElementForViolatingJSURI from './content/checkElementForViolatingJSURI';
-import checkElementForViolatingAttributes from './content/checkElementForViolatingAttributes';
+import {checkElementForViolatingAttributes} from './content/checkElementForViolatingAttributes';
 import isFbOrMsgrOrigin from './shared/isFbOrMsgrOrigin';
 import {MessagePayload} from './shared/MessagePayload';
 
 const SOURCE_SCRIPTS = new Map();
 const INLINE_SCRIPTS = [];
-const FOUND_SCRIPTS = new Map([['', []]]);
+export const FOUND_SCRIPTS = new Map([['', []]]);
 
 let currentFilterType = '';
 let manifestTimeoutID: string | number = '';

--- a/src/js/contentUtils.ts
+++ b/src/js/contentUtils.ts
@@ -19,6 +19,7 @@ import alertBackgroundOfImminentFetch from './content/alertBackgroundOfImminentF
 import {currentOrigin, updateCurrentState} from './content/updateCurrentState';
 import checkElementForViolatingJSURI from './content/checkElementForViolatingJSURI';
 import checkElementForViolatingAttributes from './content/checkElementForViolatingAttributes';
+import isFbOrMsgrOrigin from './shared/isFbOrMsgrOrigin';
 
 const SOURCE_SCRIPTS = new Map();
 const INLINE_SCRIPTS = [];
@@ -70,11 +71,7 @@ export function storeFoundJS(scriptNodeMaybe) {
     let roothash = rawManifest.root;
     let version = rawManifest.version;
 
-    if (
-      [ORIGIN_TYPE.FACEBOOK, ORIGIN_TYPE.MESSENGER].some(
-        e => e === currentOrigin.val,
-      )
-    ) {
+    if (isFbOrMsgrOrigin(currentOrigin.val)) {
       leaves = rawManifest.manifest;
       otherHashes = rawManifest.manifest_hashes;
       otherType = scriptNodeMaybe.getAttribute('data-manifest-type');
@@ -458,11 +455,7 @@ export function startFor(origin, excludedPathnames = []) {
       origin,
     })
     .then(resp => {
-      if (
-        [ORIGIN_TYPE.FACEBOOK, ORIGIN_TYPE.MESSENGER].some(
-          e => e === currentOrigin.val,
-        )
-      ) {
+      if (isFbOrMsgrOrigin(currentOrigin.val)) {
         checkCSPHeaders(resp.cspHeader, resp.cspReportHeader);
       }
     });

--- a/src/js/contentUtils.ts
+++ b/src/js/contentUtils.ts
@@ -18,7 +18,7 @@ import checkCSPHeaders from './content/checkCSPHeaders';
 import downloadJSArchive from './content/downloadJSArchive';
 import alertBackgroundOfImminentFetch from './content/alertBackgroundOfImminentFetch';
 import {currentOrigin, updateCurrentState} from './content/updateCurrentState';
-import checkElementForViolatingJSURI from './content/checkElementForViolatingJSURI';
+import checkElementForViolatingJSUri from './content/checkElementForViolatingJSUri';
 import {checkElementForViolatingAttributes} from './content/checkElementForViolatingAttributes';
 import isFbOrMsgrOrigin from './shared/isFbOrMsgrOrigin';
 import {MessagePayload} from './shared/MessagePayload';
@@ -189,7 +189,7 @@ export function storeFoundJS(scriptNodeMaybe) {
 }
 
 function checkNodeForViolations(element: Element) {
-  checkElementForViolatingJSURI(element);
+  checkElementForViolatingJSUri(element);
   checkElementForViolatingAttributes(element);
 }
 

--- a/src/js/contentUtils.ts
+++ b/src/js/contentUtils.ts
@@ -13,7 +13,6 @@ import {
   STATES,
   Origin,
 } from './config';
-// import {MessagePayload} from './shared/MessagePayload';
 
 import checkCSPHeaders from './content/checkCSPHeaders';
 import downloadJSArchive from './content/downloadJSArchive';

--- a/src/js/contentUtils.ts
+++ b/src/js/contentUtils.ts
@@ -13,25 +13,28 @@ import {
   STATES,
 } from './config';
 
-import {checkCSPHeaders} from './content/checkCSPHeaders';
-import {downloadJSArchive} from './content/downloadJSArchive';
+import checkCSPHeaders from './content/checkCSPHeaders';
+import downloadJSArchive from './content/downloadJSArchive';
 import alertBackgroundOfImminentFetch from './content/alertBackgroundOfImminentFetch';
 import {currentOrigin, updateCurrentState} from './content/updateCurrentState';
+import checkElementForViolatingJSURI from './content/checkElementForViolatingJSURI';
+import checkElementForViolatingAttributes from './content/checkElementForViolatingAttributes';
 
-const sourceScripts = new Map();
-const inlineScripts = [];
-const foundScripts = new Map();
-foundScripts.set('', []);
+const SOURCE_SCRIPTS = new Map();
+const INLINE_SCRIPTS = [];
+const FOUND_SCRIPTS = new Map([['', []]]);
+
 let currentFilterType = '';
-let manifestTimeoutID = '';
+let manifestTimeoutID: string | number = '';
 
-export function storeFoundJS(scriptNodeMaybe, scriptList) {
+export function storeFoundJS(scriptNodeMaybe) {
   if (window != window.top) {
     // this means that content utils is running in an iframe - disable timer and call processFoundJS on manifest processed in top level frame
     clearTimeout(manifestTimeoutID);
     manifestTimeoutID = '';
     window.setTimeout(
-      () => processFoundJS(currentOrigin.val, foundScripts.keys().next().value),
+      () =>
+        processFoundJS(currentOrigin.val, FOUND_SCRIPTS.keys().next().value),
       0,
     );
   }
@@ -50,7 +53,7 @@ export function storeFoundJS(scriptNodeMaybe, scriptList) {
       return;
     }
 
-    let rawManifest = '';
+    let rawManifest: string | any = '';
     try {
       rawManifest = JSON.parse(scriptNodeMaybe.textContent);
     } catch (manifestParseError) {
@@ -62,13 +65,15 @@ export function storeFoundJS(scriptNodeMaybe, scriptList) {
     }
 
     let leaves = rawManifest.leaves;
-    let otherHashes = '';
+    let otherHashes: any = '';
     let otherType = '';
     let roothash = rawManifest.root;
     let version = rawManifest.version;
 
     if (
-      [ORIGIN_TYPE.FACEBOOK, ORIGIN_TYPE.MESSENGER].includes(currentOrigin.val)
+      [ORIGIN_TYPE.FACEBOOK, ORIGIN_TYPE.MESSENGER].some(
+        e => e === currentOrigin.val,
+      )
     ) {
       leaves = rawManifest.manifest;
       otherHashes = rawManifest.manifest_hashes;
@@ -88,9 +93,9 @@ export function storeFoundJS(scriptNodeMaybe, scriptList) {
       currentFilterType = 'BOTH';
     }
     // now that we know the actual version of the scripts, transfer the ones we know about.
-    if (foundScripts.has('')) {
-      foundScripts.set(version, foundScripts.get(''));
-      foundScripts.delete('');
+    if (FOUND_SCRIPTS.has('')) {
+      FOUND_SCRIPTS.set(version, FOUND_SCRIPTS.get(''));
+      FOUND_SCRIPTS.delete('');
     }
 
     chrome.runtime.sendMessage(
@@ -162,8 +167,8 @@ export function storeFoundJS(scriptNodeMaybe, scriptList) {
   const otherType = dataBtManifest == null ? '' : dataBtManifest.split('_')[1];
   // need to get the src of the JS
   if (scriptNodeMaybe.src != null && scriptNodeMaybe.src !== '') {
-    if (scriptList.size === 1) {
-      scriptList.get(scriptList.keys().next().value).push({
+    if (FOUND_SCRIPTS.size === 1) {
+      FOUND_SCRIPTS.get(FOUND_SCRIPTS.keys().next().value).push({
         src: scriptNodeMaybe.src,
         otherType: otherType, // TODO: read from DOM when available
       });
@@ -173,8 +178,8 @@ export function storeFoundJS(scriptNodeMaybe, scriptList) {
     const hashLookupAttribute =
       scriptNodeMaybe.attributes['data-binary-transparency-hash-key'];
     const hashLookupKey = hashLookupAttribute && hashLookupAttribute.value;
-    if (scriptList.size === 1) {
-      scriptList.get(scriptList.keys().next().value).push({
+    if (FOUND_SCRIPTS.size === 1) {
+      FOUND_SCRIPTS.get(FOUND_SCRIPTS.keys().next().value).push({
         type: MESSAGE_TYPE.RAW_JS,
         rawjs: scriptNodeMaybe.innerHTML,
         lookupKey: hashLookupKey,
@@ -185,136 +190,24 @@ export function storeFoundJS(scriptNodeMaybe, scriptList) {
   updateCurrentState(STATES.PROCESSING);
 }
 
-function getAttributeValue(
-  nodeName,
-  checkNode,
-  htmlElement,
-  attributeName,
-  currentAttributeValue,
-) {
-  if (
-    nodeName.toLowerCase() === checkNode &&
-    htmlElement.hasAttribute(attributeName)
-  ) {
-    return htmlElement.getAttribute(attributeName).toLowerCase();
-  }
-  return currentAttributeValue;
+function checkNodeForViolations(element: Element) {
+  checkElementForViolatingJSURI(element);
+  checkElementForViolatingAttributes(element);
 }
 
-const AttributeCheckPairs = [
-  {nodeName: 'a', attributeName: 'href'},
-  {nodeName: 'iframe', attributeName: 'src'},
-  {nodeName: 'iframe', attributeName: 'srcdoc'},
-  {nodeName: 'form', attributeName: 'action'},
-  {nodeName: 'input', attributeName: 'formaction'},
-  {nodeName: 'button', attributeName: 'formaction'},
-  {nodeName: 'a', attributeName: 'xlink:href'},
-  {nodeName: 'ncc', attributeName: 'href'},
-  {nodeName: 'embed', attributeName: 'src'},
-  {nodeName: 'object', attributeName: 'data'},
-  {nodeName: 'animate', attributeName: 'xlink:href'},
-  {nodeName: 'script', attributeName: 'xlink:href'},
-  {nodeName: 'use', attributeName: 'href'},
-  {nodeName: 'use', attributeName: 'xlink:href'},
-  {nodeName: 'x', attributeName: 'href'},
-  {nodeName: 'x', attributeName: 'xlink:href'},
-];
-
-export function hasViolatingJavaScriptURI(htmlElement) {
-  let checkURL = '';
-  const lowerCaseNodeName = htmlElement.nodeName.toLowerCase();
-  AttributeCheckPairs.forEach(checkPair => {
-    checkURL = getAttributeValue(
-      lowerCaseNodeName,
-      checkPair.nodeName,
-      htmlElement,
-      checkPair.attributeName,
-      checkURL,
-    );
-  });
-  if (checkURL !== '') {
-    // make sure anchor tags and object tags don't have javascript urls
-    if (checkURL.indexOf('javascript') >= 0) {
-      chrome.runtime.sendMessage({
-        type: MESSAGE_TYPE.DEBUG,
-        log: 'violating attribute: javascript url',
-      });
-      updateCurrentState(STATES.INVALID);
-    }
-  }
-}
-
-function isEventHandlerAttribute(attribute) {
-  return attribute.indexOf('on') === 0;
-}
-
-export function hasInvalidAttributes(htmlElement) {
-  if (
-    typeof htmlElement.attributes === 'object' &&
-    Object.keys(htmlElement.attributes).length >= 1
-  ) {
-    Array.from(htmlElement.attributes).forEach(elementAttribute => {
-      // check first for violating attributes
-      if (isEventHandlerAttribute(elementAttribute.localName)) {
-        chrome.runtime.sendMessage({
-          type: MESSAGE_TYPE.DEBUG,
-          log:
-            'violating attribute ' +
-            elementAttribute.localName +
-            ' from element ' +
-            htmlElement.outerHTML,
-        });
-        updateCurrentState(STATES.INVALID);
-      }
-    });
-  }
-  // if the element is a math element, check all the attributes of the child node to ensure that there are on href or xlink:href attributes with javascript urls
-
-  if (
-    htmlElement.tagName.toLowerCase() === 'math' &&
-    Object.keys(htmlElement.attributes).length >= 1
-  ) {
-    Array.from(htmlElement.attributes).forEach(elementAttribute => {
-      if (
-        (elementAttribute.localName === 'href' ||
-          elementAttribute.localName === 'xlink:href') &&
-        htmlElement
-          .getAttribute(elementAttribute.localName)
-          .toLowerCase()
-          .startsWith('javascript')
-      ) {
-        chrome.runtime.sendMessage({
-          type: MESSAGE_TYPE.DEBUG,
-          log:
-            'violating attribute ' +
-            elementAttribute.localName +
-            ' from element ' +
-            htmlElement.outerHTML,
-        });
-        updateCurrentState(STATES.INVALID);
-      }
-    });
-  }
-}
-
-function checkNodeForViolations(element) {
-  hasViolatingJavaScriptURI(element);
-  hasInvalidAttributes(element);
-}
-
-export function hasInvalidScripts(scriptNodeMaybe, scriptList) {
+export function hasInvalidScripts(scriptNodeMaybe: Node) {
   // if not an HTMLElement ignore it!
   if (scriptNodeMaybe.nodeType !== 1) {
     return;
   }
 
-  checkNodeForViolations(scriptNodeMaybe);
+  checkNodeForViolations(scriptNodeMaybe as Element);
 
   if (scriptNodeMaybe.nodeName.toLowerCase() === 'script') {
-    storeFoundJS(scriptNodeMaybe, scriptList);
+    storeFoundJS(scriptNodeMaybe);
   } else if (scriptNodeMaybe.childNodes.length > 0) {
     scriptNodeMaybe.childNodes.forEach(childNode => {
-      hasInvalidScripts(childNode, scriptList);
+      hasInvalidScripts(childNode);
     });
   }
 }
@@ -326,7 +219,7 @@ export const scanForScripts = () => {
     checkNodeForViolations(element);
     // next check for existing script elements and if they're violating
     if (element.nodeName.toLowerCase() === 'script') {
-      storeFoundJS(element, foundScripts);
+      storeFoundJS(element);
     }
   });
 
@@ -336,19 +229,13 @@ export const scanForScripts = () => {
       mutationsList.forEach(mutation => {
         if (mutation.type === 'childList') {
           Array.from(mutation.addedNodes).forEach(checkScript => {
-            hasInvalidScripts(checkScript, foundScripts);
+            hasInvalidScripts(checkScript);
           });
         } else if (
           mutation.type === 'attributes' &&
-          checkNodeForViolations(mutation.target, false)
+          mutation.target.nodeType === 1
         ) {
-          updateCurrentState(STATES.INVALID);
-          chrome.runtime.sendMessage({
-            type: MESSAGE_TYPE.DEBUG,
-            log:
-              'Processed DOM mutation and invalid attribute added or changed ' +
-              mutation.target,
-          });
+          checkNodeForViolations(mutation.target as Element);
         }
       });
     });
@@ -417,7 +304,7 @@ async function processJSWithSrc(script, origin, version) {
     if (DOWNLOAD_JS_ENABLED) {
       const fileNameArr = script.src.split('/');
       const fileName = fileNameArr[fileNameArr.length - 1].split('?')[0];
-      sourceScripts.set(
+      SOURCE_SCRIPTS.set(
         fileName,
         sourceResponse
           .clone()
@@ -438,7 +325,7 @@ async function processJSWithSrc(script, origin, version) {
           },
           response => {
             if (response.valid) {
-              resolve();
+              resolve(null);
             } else {
               reject(response.type);
             }
@@ -457,8 +344,7 @@ async function processJSWithSrc(script, origin, version) {
 }
 
 export const processFoundJS = async (origin, version) => {
-  // foundScripts
-  const fullscripts = foundScripts.get(version).splice(0);
+  const fullscripts = FOUND_SCRIPTS.get(version).splice(0);
   const scripts = fullscripts.filter(script => {
     if (
       script.otherType === currentFilterType ||
@@ -466,7 +352,7 @@ export const processFoundJS = async (origin, version) => {
     ) {
       return true;
     } else {
-      foundScripts.get(version).push(script);
+      FOUND_SCRIPTS.get(version).push(script);
     }
   });
   let pendingScriptCount = scripts.length;
@@ -505,17 +391,17 @@ export const processFoundJS = async (origin, version) => {
         },
         response => {
           pendingScriptCount--;
-          let inlineScriptMap = new Map();
+          const inlineScriptMap = new Map();
           if (response.valid) {
             inlineScriptMap.set(response.hash, script.rawjs);
-            inlineScripts.push(inlineScriptMap);
+            INLINE_SCRIPTS.push(inlineScriptMap);
             if (pendingScriptCount == 0) {
               updateCurrentState(STATES.VALID);
             }
           } else {
             // using an array of maps, as we're using the same key for inline scripts - this will eventually be removed, once inline scripts are removed from the page load
             inlineScriptMap.set('hash not in manifest', script.rawjs);
-            inlineScripts.push(inlineScriptMap);
+            INLINE_SCRIPTS.push(inlineScriptMap);
             if (KNOWN_EXTENSION_HASHES.includes(response.hash)) {
               updateCurrentState(STATES.RISK);
             } else {
@@ -573,8 +459,8 @@ export function startFor(origin, excludedPathnames = []) {
     })
     .then(resp => {
       if (
-        [ORIGIN_TYPE.FACEBOOK, ORIGIN_TYPE.MESSENGER].includes(
-          currentOrigin.val,
+        [ORIGIN_TYPE.FACEBOOK, ORIGIN_TYPE.MESSENGER].some(
+          e => e === currentOrigin.val,
         )
       ) {
         checkCSPHeaders(resp.cspHeader, resp.cspReportHeader);
@@ -588,7 +474,7 @@ export function startFor(origin, excludedPathnames = []) {
   if ([ORIGIN_TYPE.FACEBOOK, ORIGIN_TYPE.MESSENGER].includes(origin)) {
     const cookies = document.cookie.split(';');
     cookies.forEach(cookie => {
-      let pair = cookie.split('=');
+      const pair = cookie.split('=');
       // c_user contains the user id of the user logged in
       if (pair[0].indexOf('c_user') >= 0) {
         isUserLoggedIn = true;
@@ -604,7 +490,7 @@ export function startFor(origin, excludedPathnames = []) {
     scanForScripts();
     // set the timeout once, in case there's an iframe and contentUtils sets another manifest timer
     if (manifestTimeoutID === '') {
-      manifestTimeoutID = setTimeout(() => {
+      manifestTimeoutID = window.setTimeout(() => {
         // Manifest failed to load, flag a warning to the user.
         updateCurrentState(STATES.TIMEOUT);
       }, 45000);
@@ -614,7 +500,7 @@ export function startFor(origin, excludedPathnames = []) {
 
 chrome.runtime.onMessage.addListener(function (request) {
   if (request.greeting === 'downloadSource' && DOWNLOAD_JS_ENABLED) {
-    downloadJSArchive(sourceScripts, inlineScripts);
+    downloadJSArchive(SOURCE_SCRIPTS, INLINE_SCRIPTS);
   } else if (request.greeting === 'nocacheHeaderFound') {
     updateCurrentState(STATES.INVALID);
   }

--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {MessagePayload} from './shared/MessagePayload';
-
 export {};
 
 type CompressionFormat = 'deflate' | 'deflate-raw' | 'gzip';

--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import {MessagePayload} from './shared/MessagePayload';
+
 export {};
 
 type CompressionFormat = 'deflate' | 'deflate-raw' | 'gzip';

--- a/src/js/shared/MessagePayload.d.ts
+++ b/src/js/shared/MessagePayload.d.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {MESSAGE_TYPE, Origin, State} from '../config';
+
+export type MessagePayload =
+  | {
+      type: typeof MESSAGE_TYPE.LOAD_MANIFEST;
+      origin: Origin;
+      rootHash: string;
+      otherHashes: {
+        combined_hash: string;
+        longtail: string;
+        main: string;
+      };
+      leaves: Array<string>;
+      version: string;
+      workaround: string;
+    }
+  | {
+      type: typeof MESSAGE_TYPE.RAW_JS;
+      rawjs: string;
+      origin: Origin;
+      version: string;
+    }
+  | {
+      type: typeof MESSAGE_TYPE.DEBUG;
+      log: string;
+    }
+  | {
+      type: typeof MESSAGE_TYPE.GET_DEBUG;
+      tabId: number;
+    }
+  | {
+      type: typeof MESSAGE_TYPE.UPDATE_STATE;
+      state: State;
+      origin: Origin;
+    }
+  | {
+      type: typeof MESSAGE_TYPE.CONTENT_SCRIPT_START;
+      origin: Origin;
+    }
+  | {
+      type: typeof MESSAGE_TYPE.UPDATED_CACHED_SCRIPT_URLS;
+      url: string;
+    };

--- a/src/js/shared/isFbOrMsgrOrigin.ts
+++ b/src/js/shared/isFbOrMsgrOrigin.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {ORIGIN_TYPE} from '../config';
+
+export default function isFbOrMsgrOrigin(origin: string): boolean {
+  return [ORIGIN_TYPE.FACEBOOK, ORIGIN_TYPE.MESSENGER].some(e => e === origin);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -313,6 +313,18 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@eslint-community/eslint-utils@^4.2.0":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
+  integrity sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==
+  dependencies:
+    eslint-visitor-keys "^3.3.0"
+
+"@eslint-community/regexpp@^4.4.0":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.5.1.tgz#cdd35dce4fa1a89a4fd42b1599eb35b3af408884"
+  integrity sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==
+
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.3.tgz#9e42981ef035beb3dd49add17acb96e8ff6f394c"
@@ -328,6 +340,35 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@eslint/eslintrc@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-2.0.3.tgz#4910db5505f4d503f27774bf356e3704818a0331"
+  integrity sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==
+  dependencies:
+    ajv "^6.12.4"
+    debug "^4.3.2"
+    espree "^9.5.2"
+    globals "^13.19.0"
+    ignore "^5.2.0"
+    import-fresh "^3.2.1"
+    js-yaml "^4.1.0"
+    minimatch "^3.1.2"
+    strip-json-comments "^3.1.1"
+
+"@eslint/js@8.40.0":
+  version "8.40.0"
+  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.40.0.tgz#3ba73359e11f5a7bd3e407f70b3528abfae69cec"
+  integrity sha512-ElyB54bJIhXQYVKjDSvCkPO1iU1tSAeVQJbllWJq1XQSmmA4dgFk8CbiBGpiOPxleE48vDogxCtmMYku4HSVLA==
+
+"@humanwhocodes/config-array@^0.11.8":
+  version "0.11.8"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.8.tgz#03595ac2075a4dc0f191cc2131de14fbd7d410b9"
+  integrity sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==
+  dependencies:
+    "@humanwhocodes/object-schema" "^1.2.1"
+    debug "^4.1.1"
+    minimatch "^3.0.5"
+
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.5.0.tgz#1407967d4c6eecd7388f83acf1eaf4d0c6e58ef9"
@@ -337,10 +378,20 @@
     debug "^4.1.1"
     minimatch "^3.0.4"
 
+"@humanwhocodes/module-importer@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz#af5b2691a22b44be847b0ca81641c5fb6ad0172c"
+  integrity sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==
+
 "@humanwhocodes/object-schema@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz#87de7af9c231826fdd68ac7258f77c429e0e5fcf"
   integrity sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==
+
+"@humanwhocodes/object-schema@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
+  integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
@@ -606,7 +657,7 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz#5bd262af94e9d25bd1e71b05deed44876a222e8b"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
 
-"@nodelib/fs.walk@^1.2.3":
+"@nodelib/fs.walk@^1.2.3", "@nodelib/fs.walk@^1.2.8":
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz#e95737e8bb6746ddedf69c556953494f196fe69a"
   integrity sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==
@@ -614,13 +665,13 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@rollup/plugin-eslint@^8.0.2":
-  version "8.0.2"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-eslint/-/plugin-eslint-8.0.2.tgz#8de988797a199cdce29b2370f6674f4302454935"
-  integrity sha512-XI38cLYfl/jww8KklJT/ji0yJbCyHgFWPbVQlGrgWblWgHlngteOJDhqtc+7iy5ek0q8k6tvBYkbCQwMScEJHA==
+"@rollup/plugin-eslint@^9.0.3":
+  version "9.0.3"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-eslint/-/plugin-eslint-9.0.3.tgz#f5e8c22d557bef02570e4f1770fb085568ea4b37"
+  integrity sha512-iV2m9BhPdsjQzmRVe3Nzovrjxbdq5Slva8bvUSzbM4gSBUaGXAFnFXcHcvO4N4tSuirZoY61mkn8KtV3G6o0iQ==
   dependencies:
-    "@rollup/pluginutils" "^4.0.0"
-    eslint "^7.12.0"
+    "@rollup/pluginutils" "^5.0.1"
+    eslint "^8.24.0"
 
 "@rollup/plugin-typescript@^11.0.0":
   version "11.0.0"
@@ -629,14 +680,6 @@
   dependencies:
     "@rollup/pluginutils" "^5.0.1"
     resolve "^1.22.1"
-
-"@rollup/pluginutils@^4.0.0":
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-4.2.1.tgz#e6c6c3aba0744edce3fb2074922d3776c0af2a6d"
-  integrity sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==
-  dependencies:
-    estree-walker "^2.0.1"
-    picomatch "^2.2.2"
 
 "@rollup/pluginutils@^5.0.1":
   version "5.0.2"
@@ -909,7 +952,7 @@ acorn-globals@^6.0.0:
     acorn "^7.1.1"
     acorn-walk "^7.1.1"
 
-acorn-jsx@^5.3.1:
+acorn-jsx@^5.3.1, acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
@@ -924,7 +967,7 @@ acorn@^7.1.1, acorn@^7.4.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-acorn@^8.2.4:
+acorn@^8.2.4, acorn@^8.8.0:
   version "8.8.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.2.tgz#1b2f25db02af965399b9776b0c2c391276d37c4a"
   integrity sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==
@@ -1006,6 +1049,11 @@ argparse@^1.0.7:
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
+
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
 array-union@^2.1.0:
   version "2.1.0"
@@ -1284,7 +1332,7 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.4:
+debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -1433,6 +1481,14 @@ eslint-scope@^5.1.1:
     esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
+eslint-scope@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.2.0.tgz#f21ebdafda02352f103634b96dd47d9f81ca117b"
+  integrity sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==
+  dependencies:
+    esrecurse "^4.3.0"
+    estraverse "^5.2.0"
+
 eslint-utils@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
@@ -1462,7 +1518,12 @@ eslint-visitor-keys@^3.3.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
   integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
 
-eslint@^7.12.0, eslint@^7.32.0:
+eslint-visitor-keys@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz#c22c48f48942d08ca824cc526211ae400478a994"
+  integrity sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==
+
+eslint@^7.32.0:
   version "7.32.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.32.0.tgz#c6d328a14be3fb08c8d1d21e12c02fdb7a2a812d"
   integrity sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==
@@ -1508,6 +1569,52 @@ eslint@^7.12.0, eslint@^7.32.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
+eslint@^8.24.0:
+  version "8.40.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.40.0.tgz#a564cd0099f38542c4e9a2f630fa45bf33bc42a4"
+  integrity sha512-bvR+TsP9EHL3TqNtj9sCNJVAFK3fBN8Q7g5waghxyRsPLIMwL73XSKnZFK0hk/O2ANC+iAoq6PWMQ+IfBAJIiQ==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.2.0"
+    "@eslint-community/regexpp" "^4.4.0"
+    "@eslint/eslintrc" "^2.0.3"
+    "@eslint/js" "8.40.0"
+    "@humanwhocodes/config-array" "^0.11.8"
+    "@humanwhocodes/module-importer" "^1.0.1"
+    "@nodelib/fs.walk" "^1.2.8"
+    ajv "^6.10.0"
+    chalk "^4.0.0"
+    cross-spawn "^7.0.2"
+    debug "^4.3.2"
+    doctrine "^3.0.0"
+    escape-string-regexp "^4.0.0"
+    eslint-scope "^7.2.0"
+    eslint-visitor-keys "^3.4.1"
+    espree "^9.5.2"
+    esquery "^1.4.2"
+    esutils "^2.0.2"
+    fast-deep-equal "^3.1.3"
+    file-entry-cache "^6.0.1"
+    find-up "^5.0.0"
+    glob-parent "^6.0.2"
+    globals "^13.19.0"
+    grapheme-splitter "^1.0.4"
+    ignore "^5.2.0"
+    import-fresh "^3.0.0"
+    imurmurhash "^0.1.4"
+    is-glob "^4.0.0"
+    is-path-inside "^3.0.3"
+    js-sdsl "^4.1.4"
+    js-yaml "^4.1.0"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.4.1"
+    lodash.merge "^4.6.2"
+    minimatch "^3.1.2"
+    natural-compare "^1.4.0"
+    optionator "^0.9.1"
+    strip-ansi "^6.0.1"
+    strip-json-comments "^3.1.0"
+    text-table "^0.2.0"
+
 espree@^7.3.0, espree@^7.3.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/espree/-/espree-7.3.1.tgz#f2df330b752c6f55019f8bd89b7660039c1bbbb6"
@@ -1516,6 +1623,15 @@ espree@^7.3.0, espree@^7.3.1:
     acorn "^7.4.0"
     acorn-jsx "^5.3.1"
     eslint-visitor-keys "^1.3.0"
+
+espree@^9.5.2:
+  version "9.5.2"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-9.5.2.tgz#e994e7dc33a082a7a82dceaf12883a829353215b"
+  integrity sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==
+  dependencies:
+    acorn "^8.8.0"
+    acorn-jsx "^5.3.2"
+    eslint-visitor-keys "^3.4.1"
 
 esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
@@ -1526,6 +1642,13 @@ esquery@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.0.tgz#2148ffc38b82e8c7057dfed48425b3e61f0f24a5"
   integrity sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==
+  dependencies:
+    estraverse "^5.1.0"
+
+esquery@^1.4.2:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.5.0.tgz#6ce17738de8577694edd7361c57182ac8cb0db0b"
+  integrity sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==
   dependencies:
     estraverse "^5.1.0"
 
@@ -1551,7 +1674,7 @@ estraverse@^5.2.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
 
-estree-walker@^2.0.1, estree-walker@^2.0.2:
+estree-walker@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
   integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
@@ -1664,6 +1787,14 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+find-up@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
+  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
+  dependencies:
+    locate-path "^6.0.0"
+    path-exists "^4.0.0"
+
 flat-cache@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
@@ -1733,6 +1864,13 @@ glob-parent@^5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
+glob-parent@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
+  integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
+  dependencies:
+    is-glob "^4.0.3"
+
 glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
@@ -1749,6 +1887,13 @@ globals@^11.1.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
+
+globals@^13.19.0:
+  version "13.20.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-13.20.0.tgz#ea276a1e508ffd4f1612888f9d1bad1e2717bf82"
+  integrity sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==
+  dependencies:
+    type-fest "^0.20.2"
 
 globals@^13.6.0, globals@^13.9.0:
   version "13.11.0"
@@ -1926,6 +2071,11 @@ is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
+
+is-path-inside@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
+  integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
 
 is-potential-custom-element-name@^1.0.1:
   version "1.0.1"
@@ -2446,6 +2596,11 @@ jest@^27.1.0:
     import-local "^3.0.2"
     jest-cli "^27.5.1"
 
+js-sdsl@^4.1.4:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/js-sdsl/-/js-sdsl-4.4.0.tgz#8b437dbe642daa95760400b602378ed8ffea8430"
+  integrity sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -2458,6 +2613,13 @@ js-yaml@^3.13.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+js-yaml@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
 
 jsdom@^16.6.0:
   version "16.7.0"
@@ -2560,6 +2722,13 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+locate-path@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
+  integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
+  dependencies:
+    p-locate "^5.0.0"
+
 lodash.clonedeep@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
@@ -2653,7 +2822,7 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
-minimatch@^3.0.4, minimatch@^3.1.1:
+minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
@@ -2747,12 +2916,26 @@ p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
+p-limit@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
+  integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
+  dependencies:
+    yocto-queue "^0.1.0"
+
 p-locate@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-4.1.0.tgz#a3428bb7088b3a60292f66919278b7c297ad4f07"
   integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
   dependencies:
     p-limit "^2.2.0"
+
+p-locate@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
+  integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
+  dependencies:
+    p-limit "^3.0.2"
 
 p-try@^2.0.0:
   version "2.2.0"
@@ -2811,7 +2994,7 @@ picocolors@^1.0.0:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
-picomatch@^2.0.4, picomatch@^2.2.2, picomatch@^2.2.3, picomatch@^2.3.1:
+picomatch@^2.0.4, picomatch@^2.2.3, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
@@ -3483,3 +3666,8 @@ yargs@^16.2.0:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
+
+yocto-queue@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
+  integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==


### PR DESCRIPTION
- Upgrade rollup eslint plugin, it seems to be incorrectly complaining about nullish coalescing and optional chaining operators which TS compiles into statements using `var`
- contentUtils.js -> contentUtils.ts
- Pull our methods for validating nodes
- Module level constants to SNAKE_UPPER_CASE
- Change some named exports to default exports
- Create shared util to check for FB/MSGR origin
- **Created type for content -> BG message payloads as we were sending a lot of unused values.**