### PR TITLE
Ensure CSP checks work when there are multiple CSP headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "watch": "yarn build -w",
     "lint": "yarn beautify && yarn run eslint src/js/**",
     "beautify": "yarn run prettier --write \"src/**/*.(ts|js)\" \"build/**/*.ts\"",
-    "test": "yarn lint && node --experimental-vm-modules --no-warnings node_modules/jest/bin/jest.js"
+    "test": "node --experimental-vm-modules --no-warnings node_modules/jest/bin/jest.js"
   },
   "devDependencies": {
     "@rollup/plugin-eslint": "^9.0.3",

--- a/src/js/__tests__/checkCSPHeaders-test.js
+++ b/src/js/__tests__/checkCSPHeaders-test.js
@@ -101,7 +101,7 @@ describe('checkCSPHeaders', () => {
     );
     expect(isValid).toBeTruthy();
   });
-  it('Should be valid if one of the policies is enforcing, both script-src', () => {
+  it('Should be valid if one of the policies is enforcing, both default-src', () => {
     const isValid = checkCSPHeaders(
       [
         `default-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
@@ -131,7 +131,7 @@ describe('checkCSPHeaders', () => {
     );
     expect(isValid).toBeTruthy();
   });
-  it('Should be valid if one of the policies is enforcing, script-src precedence', () => {
+  it('Should be valid if one of the policies is enforcing, default-src precedence', () => {
     const isValid = checkCSPHeaders(
       [
         ``,
@@ -173,7 +173,7 @@ describe('checkCSPHeaders', () => {
     );
     expect(isValid).toBeTruthy();
   });
-  it('Should be valid if one of the policies is reporting, both script-src', () => {
+  it('Should be valid if one of the policies is reporting, both default-src', () => {
     const isValid = checkCSPHeaders(
       [],
       [
@@ -185,11 +185,11 @@ describe('checkCSPHeaders', () => {
   });
   it('Should be valid if one of the policies is reporting, script-src precedence', () => {
     const isValid = checkCSPHeaders(
+      [],
       [
         `default-src 'unsafe-eval';`,
         `script-src *.facebook.com *.fbcdn.net blob: data: 'self';`,
       ],
-      [],
     );
     expect(isValid).toBeTruthy();
   });
@@ -200,7 +200,7 @@ describe('checkCSPHeaders', () => {
     );
     expect(isValid).toBeTruthy();
   });
-  it('Should be valid if one of the policies is reporting, script-src precedence', () => {
+  it('Should be valid if one of the policies is reporting, default-src precedence', () => {
     const isValid = checkCSPHeaders(
       [],
       [``, `default-src *.facebook.com *.fbcdn.net blob: data: 'self';`],

--- a/src/js/__tests__/checkCSPHeaders-test.js
+++ b/src/js/__tests__/checkCSPHeaders-test.js
@@ -1,0 +1,231 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import {jest} from '@jest/globals';
+import {checkCSPHeaders} from '../content/checkCSPHeaders';
+
+describe('checkCSPHeaders', () => {
+  beforeEach(() => {
+    window.chrome.runtime.sendMessage = jest.fn(() => {});
+  });
+  // Enforce precedence
+  it('Enforce valid policy from script-src', () => {
+    const isValid = checkCSPHeaders(
+      [
+        `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
+          `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';`,
+      ],
+      [],
+    );
+    expect(isValid).toBeTruthy();
+  });
+  it('Enforce valid policy from default-src', () => {
+    const isValid = checkCSPHeaders(
+      [
+        `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';`,
+      ],
+      [],
+    );
+    expect(isValid).toBeTruthy();
+  });
+  it('Enforce invalid due to script-src, missing Report policy', () => {
+    const isValid = checkCSPHeaders(
+      [
+        `default-src data: blob: 'self' *.facebook.com *.fbcdn.net;` +
+          `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
+      ],
+      [],
+    );
+    expect(isValid).toBeFalsy();
+  });
+  it('Enforce invalid due to default-src, missing Report policy', () => {
+    const isValid = checkCSPHeaders(
+      [
+        `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'unsafe-eval';`,
+      ],
+      [],
+    );
+    expect(isValid).toBeFalsy();
+  });
+  // Report affecting outcome
+  it('Enforce invalid, correct Report policy because of script-src', () => {
+    const isValid = checkCSPHeaders(
+      [],
+      [
+        `default-src data: blob: 'self' *.facebook.com *.fbcdn.net;` +
+          `script-src *.facebook.com *.fbcdn.net blob: data: 'self';`,
+      ],
+    );
+    expect(isValid).toBeTruthy();
+  });
+  it('Enforce invalid, correct Report policy because of default-src', () => {
+    const isValid = checkCSPHeaders(
+      [],
+      [`default-src data: blob: 'self' *.facebook.com *.fbcdn.net;`],
+    );
+    expect(isValid).toBeTruthy();
+  });
+  it('Enforce invalid, incorrect Report policy because of script-src', () => {
+    const isValid = checkCSPHeaders(
+      [],
+      [
+        `default-src data: blob: 'self' *.facebook.com *.fbcdn.net;` +
+          `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
+      ],
+    );
+    expect(isValid).toBeFalsy();
+  });
+  it('Enforce invalid, incorrect Report policy because of default-src', () => {
+    const isValid = checkCSPHeaders(
+      [],
+      [
+        `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'unsafe-eval';`,
+      ],
+    );
+    expect(isValid).toBeFalsy();
+  });
+  // Multiple policies, enforcement
+  it('Should be valid if one of the policies is enforcing, both script-src', () => {
+    const isValid = checkCSPHeaders(
+      [
+        `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
+        `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';`,
+      ],
+      [],
+    );
+    expect(isValid).toBeTruthy();
+  });
+  it('Should be valid if one of the policies is enforcing, both script-src', () => {
+    const isValid = checkCSPHeaders(
+      [
+        `default-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
+        `default-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';`,
+      ],
+      [],
+    );
+    expect(isValid).toBeTruthy();
+  });
+  it('Should be valid if one of the policies is enforcing, script-src precedence', () => {
+    const isValid = checkCSPHeaders(
+      [
+        `default-src 'unsafe-eval';`,
+        `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';`,
+      ],
+      [],
+    );
+    expect(isValid).toBeTruthy();
+  });
+  it('Should be valid if one of the policies is enforcing, script-src precedence', () => {
+    const isValid = checkCSPHeaders(
+      [
+        ``,
+        `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';`,
+      ],
+      [],
+    );
+    expect(isValid).toBeTruthy();
+  });
+  it('Should be valid if one of the policies is enforcing, script-src precedence', () => {
+    const isValid = checkCSPHeaders(
+      [
+        ``,
+        `default-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';`,
+      ],
+      [],
+    );
+    expect(isValid).toBeTruthy();
+  });
+  it('Should be invalid if policy with precedence is not enforcing, script-src precedence', () => {
+    const isValid = checkCSPHeaders(
+      [
+        `default-src *.facebook.com;`,
+        `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
+      ],
+      [],
+    );
+    expect(isValid).toBeFalsy();
+  });
+  it('Should be invalid if none of the policies are enforcing, script-src precedence', () => {
+    const isValid = checkCSPHeaders(
+      [
+        `default-src *.facebook.com;` +
+          `script-src *.facebook.com 'unsafe-eval';`,
+        `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
+      ],
+      [],
+    );
+    expect(isValid).toBeFalsy();
+  });
+  // Multiple policies, report-only
+  it('Should be valid if one of the policies is reporting, both script-src', () => {
+    const isValid = checkCSPHeaders(
+      [],
+      [
+        `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
+        `script-src *.facebook.com *.fbcdn.net blob: data: 'self';`,
+      ],
+    );
+    expect(isValid).toBeTruthy();
+  });
+  it('Should be valid if one of the policies is reporting, both script-src', () => {
+    const isValid = checkCSPHeaders(
+      [],
+      [
+        `default-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
+        `default-src *.facebook.com *.fbcdn.net blob: data: 'self';`,
+      ],
+    );
+    expect(isValid).toBeTruthy();
+  });
+  it('Should be valid if one of the policies is reporting, script-src precedence', () => {
+    const isValid = checkCSPHeaders(
+      [
+        `default-src 'unsafe-eval';`,
+        `script-src *.facebook.com *.fbcdn.net blob: data: 'self';`,
+      ],
+      [],
+    );
+    expect(isValid).toBeTruthy();
+  });
+  it('Should be valid if one of the policies is reporting, script-src precedence', () => {
+    const isValid = checkCSPHeaders(
+      [],
+      [``, `script-src *.facebook.com *.fbcdn.net blob: data: 'self';`],
+    );
+    expect(isValid).toBeTruthy();
+  });
+  it('Should be valid if one of the policies is reporting, script-src precedence', () => {
+    const isValid = checkCSPHeaders(
+      [],
+      [``, `default-src *.facebook.com *.fbcdn.net blob: data: 'self';`],
+    );
+    expect(isValid).toBeTruthy();
+  });
+  it('Should be invalid if policy with precedence is not reporting, script-src precedence', () => {
+    const isValid = checkCSPHeaders(
+      [],
+      [
+        `default-src *.facebook.com;`,
+        `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
+      ],
+    );
+    expect(isValid).toBeFalsy();
+  });
+  it('Should be invalid if none of the policies are reporting, script-src precedence', () => {
+    const isValid = checkCSPHeaders(
+      [],
+      [
+        `default-src *.facebook.com;` +
+          `script-src *.facebook.com 'unsafe-eval';`,
+        `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
+      ],
+    );
+    expect(isValid).toBeFalsy();
+  });
+});

--- a/src/js/background.ts
+++ b/src/js/background.ts
@@ -21,8 +21,9 @@ import {MessagePayload, MessageResponse} from './shared/MessageTypes';
 
 const MANIFEST_CACHE = new Map<Origin, Map<string, Manifest>>();
 
-// TabID -> FrameID -> CSP Header Values
-export type CSPHeaderMap = Map<number, Map<number, string | undefined>>;
+// TabID -> FrameID -> Array<CSP Header Values>
+// There might be multiple CSP policy headers per response
+export type CSPHeaderMap = Map<number, Map<number, Array<string>>>;
 const CSP_HEADERS: CSPHeaderMap = new Map();
 const CSP_REPORT_HEADERS: CSPHeaderMap = new Map();
 
@@ -187,8 +188,8 @@ function handleMessages(
     recordContentScriptStart(sender, message.origin);
     sendResponse({
       success: true,
-      cspHeader: CSP_HEADERS?.get(sender.tab.id)?.get(sender.frameId),
-      cspReportHeader: CSP_REPORT_HEADERS?.get(sender.tab.id)?.get(
+      cspHeaders: CSP_HEADERS?.get(sender.tab.id)?.get(sender.frameId),
+      cspReportHeaders: CSP_REPORT_HEADERS?.get(sender.tab.id)?.get(
         sender.frameId,
       ),
     });

--- a/src/js/background/setupCSPListener.ts
+++ b/src/js/background/setupCSPListener.ts
@@ -8,28 +8,32 @@
 import {CSPHeaderMap} from '../background';
 
 export default function setupCSPListener(
-  cspHeaders: CSPHeaderMap,
-  cspReportHeaders: CSPHeaderMap,
+  cspHeadersMap: CSPHeaderMap,
+  cspReportHeadersMap: CSPHeaderMap,
 ): void {
   chrome.webRequest.onHeadersReceived.addListener(
     details => {
       if (details.responseHeaders) {
-        const cspHeader = details.responseHeaders.find(
+        const cspHeaders = details.responseHeaders.filter(
           header => header.name === 'content-security-policy',
         );
-        const cspReportHeader = details.responseHeaders.find(
+        const cspReportHeaders = details.responseHeaders.filter(
           header => header.name === 'content-security-policy-report-only',
         );
-        if (!cspHeaders.has(details.tabId)) {
-          cspHeaders.set(details.tabId, new Map());
+        if (!cspHeadersMap.has(details.tabId)) {
+          cspHeadersMap.set(details.tabId, new Map());
         }
-        if (!cspReportHeaders.has(details.tabId)) {
-          cspReportHeaders.set(details.tabId, new Map());
+        if (!cspReportHeadersMap.has(details.tabId)) {
+          cspReportHeadersMap.set(details.tabId, new Map());
         }
-        cspHeaders.get(details.tabId).set(details.frameId, cspHeader?.value);
-        cspReportHeaders
-          .get(details.tabId)
-          .set(details.frameId, cspReportHeader?.value);
+        cspHeadersMap.get(details.tabId).set(
+          details.frameId,
+          cspHeaders.map(h => h.value),
+        );
+        cspReportHeadersMap.get(details.tabId).set(
+          details.frameId,
+          cspReportHeaders.map(h => h.value),
+        );
       }
     },
     {

--- a/src/js/content/checkCSPHeaders.ts
+++ b/src/js/content/checkCSPHeaders.ts
@@ -51,54 +51,78 @@ function scanForCSPEvalReportViolations(): void {
   });
 }
 
-export default function checkCSPHeaders(
-  cspHeaders: Array<string>,
-  cspReportHeaders: Array<string>,
-) {
-  for (const cspHeader of cspHeaders) {
-    // If CSP is enforcing on evals we don't need to do extra checks
+function getIsValidDefaultSrc(cspHeaders: Array<string>): boolean {
+  return cspHeaders.some(cspHeader => {
     const cspMap = parseCSPString(cspHeader);
-    if (cspMap.has('script-src')) {
-      if (!cspMap.get('script-src').has("'unsafe-eval'")) {
-        return;
-      }
-    }
     if (!cspMap.has('script-src') && cspMap.has('default-src')) {
       if (!cspMap.get('default-src').has("'unsafe-eval'")) {
-        return;
+        return true;
       }
+    }
+    return false;
+  });
+}
+
+function getIsValidScriptSrcAndHasScriptSrcDirective(
+  cspHeaders: Array<string>,
+): [boolean, boolean] {
+  let hasScriptSrcDirective = false;
+  const isValidScriptSrc = cspHeaders.some(cspHeader => {
+    const cspMap = parseCSPString(cspHeader);
+    if (cspMap.has('script-src')) {
+      hasScriptSrcDirective = true;
+      if (!cspMap.get('script-src').has("'unsafe-eval'")) {
+        return true;
+      }
+    }
+    return false;
+  });
+  return [isValidScriptSrc, hasScriptSrcDirective];
+}
+
+export function checkCSPHeaders(
+  cspHeaders: Array<string>,
+  cspReportHeaders: Array<string>,
+): boolean {
+  // If CSP is enforcing on evals we don't need to do extra checks
+
+  // Check `script-src` across all headers first since it takes precedence
+  // across multiple headers
+  const [hasValidScriptSrcEnforcement, hasScriptSrcDirectiveForEnforce] =
+    getIsValidScriptSrcAndHasScriptSrcDirective(cspHeaders);
+  if (hasValidScriptSrcEnforcement) {
+    return true;
+  }
+
+  if (!hasScriptSrcDirectiveForEnforce) {
+    if (getIsValidDefaultSrc(cspHeaders)) {
+      return true;
     }
   }
 
   if (cspReportHeaders.length === 0) {
     updateCurrentState(STATES.INVALID, 'Missing CSP report-only header');
-    return;
+    return false;
   }
 
   // Check if at least one header has the correct report setup
-  const hasValidReportHeader = cspReportHeaders.some(cspReportHeader => {
-    // If CSP is not reporting on evals we cannot catch them via event listeners
-    const cspReportMap = parseCSPString(cspReportHeader);
-    if (cspReportMap.has('script-src')) {
-      if (cspReportMap.get('script-src').has("'unsafe-eval'")) {
-        return false;
-      }
-    }
-    if (!cspReportMap.has('script-src') && cspReportMap.has('default-src')) {
-      if (cspReportMap.get('default-src').has("'unsafe-eval'")) {
-        return false;
-      }
-    }
-    return true;
-  });
+  // If CSP is not reporting on evals we cannot catch them via event listeners
+  const [hasValidScriptSrcReport, hasScriptSrcDirectiveForReport] =
+    getIsValidScriptSrcAndHasScriptSrcDirective(cspReportHeaders);
 
-  if (!hasValidReportHeader) {
+  let hasValidDefaultSrcReport = false;
+  if (!hasScriptSrcDirectiveForReport) {
+    hasValidDefaultSrcReport = getIsValidDefaultSrc(cspReportHeaders);
+  }
+
+  if (!hasValidScriptSrcReport && !hasValidDefaultSrcReport) {
     updateCurrentState(
       STATES.INVALID,
       'Missing unsafe-eval from CSP report-only header',
     );
-    return;
+    return false;
   }
   // Check for evals
   scanForCSPEvalReportViolations();
+  return true;
 }

--- a/src/js/contentUtils.ts
+++ b/src/js/contentUtils.ts
@@ -13,7 +13,7 @@ import {
   Origin,
 } from './config';
 
-import checkCSPHeaders from './content/checkCSPHeaders';
+import {checkCSPHeaders} from './content/checkCSPHeaders';
 import downloadJSArchive from './content/downloadJSArchive';
 import alertBackgroundOfImminentFetch from './content/alertBackgroundOfImminentFetch';
 import {currentOrigin, updateCurrentState} from './content/updateCurrentState';

--- a/src/js/contentUtils.ts
+++ b/src/js/contentUtils.ts
@@ -423,7 +423,7 @@ export function startFor(
     },
     resp => {
       if (isFbOrMsgrOrigin(currentOrigin.val)) {
-        checkCSPHeaders(resp.cspHeader, resp.cspReportHeader);
+        checkCSPHeaders(resp.cspHeaders, resp.cspReportHeaders);
       }
     },
   );

--- a/src/js/shared/MessageTypes.d.ts
+++ b/src/js/shared/MessageTypes.d.ts
@@ -54,6 +54,6 @@ export type MessageResponse = {
   debugList?: Array<string>;
   reason?: string;
   hash?: string;
-  cspHeader?: string;
-  cspReportHeader?: string;
+  cspHeaders?: Array<string>;
+  cspReportHeaders?: Array<string>;
 };


### PR DESCRIPTION
https://w3c.github.io/webappsec-csp/#multiple-policies

We need to be more careful in avoiding false positives when there are potentially multiple policies set.