### PR TITLE
Fix support for multiple manifest versions

### DIFF
--- a/src/js/__tests__/checkElementForViolatingAttributes-test.js
+++ b/src/js/__tests__/checkElementForViolatingAttributes-test.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import {checkElementForViolatingAttributes} from '../content/checkElementForViolatingAttributes';
+
+describe('contentUtils', () => {
+  describe('checkElementForViolatingAttributes', () => {
+    it('should not execute if element has no attributes', () => {
+      // no hasAttribute function
+      let fakeElement = {
+        childNodes: [],
+        tagName: 'tagName',
+      };
+      checkElementForViolatingAttributes(fakeElement);
+      expect(window.chrome.runtime.sendMessage.mock.calls.length).toBe(0);
+
+      // hasAttribute is a function, but has no attributes
+      fakeElement = {
+        hasAttribute: () => {
+          return false;
+        },
+        childNodes: [],
+        tagName: 'tagName',
+      };
+      checkElementForViolatingAttributes(fakeElement);
+      expect(window.chrome.runtime.sendMessage.mock.calls.length).toBe(0);
+    });
+    it('should not update the icon if no violating attributes are found', () => {
+      const fakeElement = {
+        attributes: [
+          {localName: 'background'},
+          {localName: 'height'},
+          {localName: 'width'},
+        ],
+        hasAttribute: () => {
+          return true;
+        },
+        childNodes: [],
+        tagName: 'div',
+      };
+      checkElementForViolatingAttributes(fakeElement);
+      expect(window.chrome.runtime.sendMessage.mock.calls.length).toBe(0);
+    });
+    it('should update the icon if violating attributes are found', () => {
+      const fakeElement = {
+        attributes: [
+          {localName: 'onclick'},
+          {localName: 'height'},
+          {localName: 'width'},
+        ],
+        hasAttributes: () => {
+          return true;
+        },
+        childNodes: [],
+        tagName: 'div',
+      };
+      checkElementForViolatingAttributes(fakeElement);
+      expect(window.chrome.runtime.sendMessage.mock.calls.length).toBe(1);
+    });
+  });
+});

--- a/src/js/__tests__/contentUtils-test.js
+++ b/src/js/__tests__/contentUtils-test.js
@@ -15,7 +15,6 @@ import {
   FOUND_SCRIPTS,
   storeFoundJS,
 } from '../contentUtils';
-import {checkElementForViolatingAttributes} from '../content/checkElementForViolatingAttributes';
 
 describe('contentUtils', () => {
   beforeEach(() => {
@@ -64,60 +63,6 @@ describe('contentUtils', () => {
     });
     it.skip('storeFoundJS keeps existing icon if not valid', () => {
       // TODO: come back to this after testing processFoundJS
-    });
-  });
-  describe('checkElementForViolatingAttributes', () => {
-    it('should not execute if element has no attributes', () => {
-      // no hasAttribute function
-      let fakeElement = {
-        childNodes: [],
-        tagName: 'tagName',
-      };
-      checkElementForViolatingAttributes(fakeElement);
-      expect(window.chrome.runtime.sendMessage.mock.calls.length).toBe(0);
-
-      // hasAttribute is a function, but has no attributes
-      fakeElement = {
-        hasAttribute: () => {
-          return false;
-        },
-        childNodes: [],
-        tagName: 'tagName',
-      };
-      checkElementForViolatingAttributes(fakeElement);
-      expect(window.chrome.runtime.sendMessage.mock.calls.length).toBe(0);
-    });
-    it('should not update the icon if no violating attributes are found', () => {
-      const fakeElement = {
-        attributes: [
-          {localName: 'background'},
-          {localName: 'height'},
-          {localName: 'width'},
-        ],
-        hasAttribute: () => {
-          return true;
-        },
-        childNodes: [],
-        tagName: 'div',
-      };
-      checkElementForViolatingAttributes(fakeElement);
-      expect(window.chrome.runtime.sendMessage.mock.calls.length).toBe(0);
-    });
-    it('should update the icon if violating attributes are found', () => {
-      const fakeElement = {
-        attributes: [
-          {localName: 'onclick'},
-          {localName: 'height'},
-          {localName: 'width'},
-        ],
-        hasAttributes: () => {
-          return true;
-        },
-        childNodes: [],
-        tagName: 'div',
-      };
-      checkElementForViolatingAttributes(fakeElement);
-      expect(window.chrome.runtime.sendMessage.mock.calls.length).toBe(1);
     });
   });
   describe('hasInvalidScripts', () => {

--- a/src/js/content/parseFailedJSON.ts
+++ b/src/js/content/parseFailedJSON.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import {STATES} from '../config';
+import {updateCurrentState} from './updateCurrentState';
+
+export default function parseFailedJson(queuedJsonToParse: {
+  node: Element;
+  retry: number;
+}): void {
+  try {
+    JSON.parse(queuedJsonToParse.node.textContent);
+  } catch (parseError) {
+    if (queuedJsonToParse.retry > 0) {
+      queuedJsonToParse.retry--;
+      setTimeout(() => parseFailedJson(queuedJsonToParse), 20);
+    } else {
+      updateCurrentState(STATES.INVALID);
+    }
+  }
+}


### PR DESCRIPTION
It seems that we are incorrectly validating JS when it comes from a different manifest version, this change makes sure script tags are attributed to the correct version.