### PR TITLE
Fix DOWNLOAD_JS_ENABLED feature flag

### DIFF
--- a/src/js/config.ts
+++ b/src/js/config.ts
@@ -114,5 +114,6 @@ export const ORIGIN_TYPE = Object.freeze({
 
 export type Origin = keyof typeof ORIGIN_TYPE;
 
-// Firefox and Safari currently do not support CompressionStream
-export const DOWNLOAD_JS_ENABLED = 'CompressionStream' in window;
+// Firefox and Safari currently do not support CompressionStream/showSaveFilePicker
+export const DOWNLOAD_JS_ENABLED =
+  'CompressionStream' in window && 'showSaveFilePicker' in window;


### PR DESCRIPTION
Firefox 113 added support for `CompressionStream` but it still does not support `showSaveFilePicker` which unintentionally started showing the download button in the extension.

<img width="292" alt="image" src="https://github.com/facebookincubator/meta-code-verify/assets/20268283/514a896d-bd91-46ed-b706-6123d47a0340">
