### PR TITLE
Fix versioning bug in #239

### DIFF
--- a/src/js/contentUtils.ts
+++ b/src/js/contentUtils.ts
@@ -119,7 +119,10 @@ export function storeFoundJS(scriptNodeMaybe: HTMLScriptElement): void {
     }
     // now that we know the actual version of the scripts, transfer the ones we know about.
     if (FOUND_SCRIPTS.has('')) {
-      FOUND_SCRIPTS.set(version, FOUND_SCRIPTS.get(''));
+      FOUND_SCRIPTS.set(version, [
+        ...FOUND_SCRIPTS.get(''),
+        ...(FOUND_SCRIPTS.get(version) ?? []),
+      ]);
       FOUND_SCRIPTS.delete('');
     } else if (!FOUND_SCRIPTS.has(version)) {
       // New version is being loaded in


### PR DESCRIPTION
#239 made an incorrect assumption that loaded script would be handled before the manifest this leaded to some scripts being skipped from being processed.

This fix ensures that if scripts with src tags are loaded before the manifest they are moved correctly to the appropriate `Map` when the manifest is loaded.