### PR TITLE
Fix edge case with nested logged out frame on logged in document

### DIFF
--- a/src/js/background/tab_state_tracker/TabStateMachine.ts
+++ b/src/js/background/tab_state_tracker/TabStateMachine.ts
@@ -61,11 +61,12 @@ export default class TabStateMachine extends StateMachine {
   }
 
   updateStateIfValid(newState: State) {
-    // Only update the tab's state to VALID if all of it's frames are VALID
+    // Only update the tab's state to VALID if all of it's frames are VALID or just starting
     if (
       newState === STATES.VALID &&
       !Object.values(this._frameStates).every(
-        fsm => fsm.getState() === STATES.VALID,
+        fsm =>
+          fsm.getState() === STATES.VALID || fsm.getState() === STATES.START,
       )
     ) {
       return;

--- a/src/js/contentUtils.ts
+++ b/src/js/contentUtils.ts
@@ -422,6 +422,7 @@ export const processFoundJS = async (version: string): Promise<void> => {
   window.setTimeout(() => processFoundJS(version), 3000);
 };
 
+let isUserLoggedIn = false;
 export function startFor(
   origin: Origin,
   excludedPathnames: Array<RegExp> = [],
@@ -441,7 +442,6 @@ export function startFor(
     updateCurrentState(STATES.IGNORE);
     return;
   }
-  let isUserLoggedIn = false;
   if (isFbMsgrOrIgOrigin(origin)) {
     // ds_user_id / c_user contains the user id of the user logged in
     const cookieName =
@@ -454,7 +454,7 @@ export function startFor(
       }
     });
   } else {
-    // only doing this check for FB and MSGR
+    // only doing this check for FB, MSGR, and IG
     isUserLoggedIn = true;
   }
   if (isUserLoggedIn) {
@@ -480,7 +480,7 @@ chrome.runtime.onMessage.addListener(request => {
       `Detected uncached script ${request.uncachedUrl}`,
     );
   } else if (request.greeting === 'checkIfScriptWasProcessed') {
-    if (!ALL_FOUND_SCRIPT_TAGS.has(request.response.url)) {
+    if (isUserLoggedIn && !ALL_FOUND_SCRIPT_TAGS.has(request.response.url)) {
       if (
         'serviceWorker' in navigator &&
         navigator.serviceWorker.controller?.scriptURL === request.response.url


### PR DESCRIPTION
This PR fixes a bug where a nested logged out frame on a logged in document could leave the extension in a suspended loading state.

- If a subframe is not logged in it's left in the "START" state, if a frame is stuck in the START state it means the user is not logged in or there is no manifest
 
- Additionally, the subframe wasn't exactly being stuck in the "START" state but in the "PROCESSING" state and this is because of the recent change we did to widen checks across the tab using webRequest. Specifically `checkIfScriptWasProcessed` event was fired back to the logged out tab although it shouldn't be since that tab is not tracking scripts, causing it to be stuck in "PROCESSING"

These fixes together should allow correct checking of a top logged in tab when it has a nested logged out tab of a different origin. 