### PR TITLE
Fix case where scripts from non-main thread could potentially be ignored

### DIFF
--- a/src/js/contentUtils.ts
+++ b/src/js/contentUtils.ts
@@ -132,7 +132,10 @@ export function storeFoundJS(scriptNodeMaybe: HTMLScriptElement): void {
     // now that we know the actual version of the scripts, transfer the ones we know about.
     if (FOUND_SCRIPTS.has('')) {
       FOUND_SCRIPTS.set(version, [
-        ...FOUND_SCRIPTS.get(''),
+        ...FOUND_SCRIPTS.get('').map(s => ({
+          ...s,
+          otherType: currentFilterType,
+        })),
         ...(FOUND_SCRIPTS.get(version) ?? []),
       ]);
       FOUND_SCRIPTS.delete('');


### PR DESCRIPTION
If scripts are detected before a `currentFilterType` is set, they might end up never being checked. This isn't an issue on facebook.com where currentFilterType eventually is set to both which [ends up checking all scripts](https://github.com/facebookincubator/meta-code-verify/blob/main/src/js/contentUtils.ts#L348), but on ig/msgr this could end up in these scripts being ignored if they are detected before the type is set. 

This fixes that.