### PR TITLE
fix extension check

### DIFF
--- a/src/js/background/setUpWebRequestsListener.ts
+++ b/src/js/background/setUpWebRequestsListener.ts
@@ -41,17 +41,19 @@ export default function setUpWebRequestsListener(
   chrome.webRequest.onResponseStarted.addListener(
     response => {
       if (response.tabId === -1) {
+        if (
+          response.url.startsWith('chrome-extension://') ||
+          response.url.startsWith('moz-extension://')
+        ) {
+          return;
+        }
         if (!isMetaInitiatedResponse(response)) {
           return;
         }
         checkResponseMIMEType(response);
 
         // Potential `importScripts` call from Shared or Service Worker
-        if (
-          !response.url.startsWith('chrome-extension://') &&
-          !response.url.startsWith('moz-extension://') &&
-          response.type === 'script'
-        ) {
+        if (response.type === 'script') {
           const origin = response.initiator;
 
           // Send to all tabs of this origin
@@ -70,6 +72,7 @@ export default function setUpWebRequestsListener(
             });
           });
         }
+
         return;
       }
 


### PR DESCRIPTION
`isMetaInitiatedResponse` was erroring because we added this check before checking for extensions which have no `initiator` field.

<img width="957" alt="Screenshot 2023-09-20 at 12 29 00 PM" src="https://github.com/facebookincubator/meta-code-verify/assets/20268283/0999c654-35bd-4209-925a-4eb797855886">

This commit moves the extension check to preceed the initiator check 