### PR TITLE
Correctly update states from RISK -> INVALID

### DIFF
--- a/src/js/background/tab_state_tracker/StateMachine.ts
+++ b/src/js/background/tab_state_tracker/StateMachine.ts
@@ -44,6 +44,7 @@ const STATE_TRANSITIONS: Partial<{
     [STATES.INVALID]: true,
   },
   [STATES.RISK]: {
+    [STATES.INVALID]: true,
     [STATES.RISK]: true,
   },
   [STATES.VALID]: {


### PR DESCRIPTION
This should be a valid state transition.

Test plan:

- Enabled some extensions until I got a risk warning
- Injected script from console and ensure state transitioned to invalid