### PR TITLE
Fix regression with missing excludedPathnames

### DIFF
--- a/src/js/contentUtils.ts
+++ b/src/js/contentUtils.ts
@@ -31,19 +31,20 @@ import {doesWorkerUrlConformToCSP} from './content/doesWorkerUrlConformToCSP';
 import {checkWorkerEndpointCSP} from './content/checkWorkerEndpointCSP';
 
 type ContentScriptConfig = {
-  scriptsShouldHaveManifestProp: boolean;
   checkLoggedInFromCookie: boolean;
-  excludedPathnames?: Array<RegExp>;
-  longTailIsLoadedConditionally: boolean;
   enforceCSPHeaders: boolean;
+  excludedPathnames: Array<RegExp>;
+  longTailIsLoadedConditionally: boolean;
+  scriptsShouldHaveManifestProp: boolean;
   useCompanyManifest: boolean;
 };
 
 let originConfig: ContentScriptConfig = {
-  scriptsShouldHaveManifestProp: false,
   checkLoggedInFromCookie: false,
   enforceCSPHeaders: false,
+  excludedPathnames: [],
   longTailIsLoadedConditionally: false,
+  scriptsShouldHaveManifestProp: false,
   useCompanyManifest: false,
 };
 

--- a/src/js/detectFBMeta.ts
+++ b/src/js/detectFBMeta.ts
@@ -28,11 +28,11 @@ const EXCLUDED_PATHNAMES: Array<RegExp> = [
 startFor(
   ORIGIN_TYPE.FACEBOOK,
   Object.freeze({
-    scriptsShouldHaveManifestProp: true,
     checkLoggedInFromCookie: true,
-    excludedPathnames: EXCLUDED_PATHNAMES,
     enforceCSPHeaders: true,
+    excludedPathnames: EXCLUDED_PATHNAMES,
     longTailIsLoadedConditionally: true,
+    scriptsShouldHaveManifestProp: true,
     useCompanyManifest: true,
   }),
 );

--- a/src/js/detectIGMeta.ts
+++ b/src/js/detectIGMeta.ts
@@ -11,10 +11,11 @@ import {startFor} from './contentUtils.js';
 startFor(
   ORIGIN_TYPE.INSTAGRAM,
   Object.freeze({
-    scriptsShouldHaveManifestProp: true,
     checkLoggedInFromCookie: true,
     enforceCSPHeaders: true,
+    excludedPathnames: [],
     longTailIsLoadedConditionally: true,
+    scriptsShouldHaveManifestProp: true,
     useCompanyManifest: true,
   }),
 );

--- a/src/js/detectMSGRMeta.ts
+++ b/src/js/detectMSGRMeta.ts
@@ -11,10 +11,11 @@ import {startFor} from './contentUtils.js';
 startFor(
   ORIGIN_TYPE.MESSENGER,
   Object.freeze({
-    scriptsShouldHaveManifestProp: true,
     checkLoggedInFromCookie: true,
     enforceCSPHeaders: true,
+    excludedPathnames: [],
     longTailIsLoadedConditionally: true,
+    scriptsShouldHaveManifestProp: true,
     useCompanyManifest: true,
   }),
 );

--- a/src/js/detectWAMeta.ts
+++ b/src/js/detectWAMeta.ts
@@ -11,10 +11,11 @@ import {startFor} from './contentUtils.js';
 startFor(
   ORIGIN_TYPE.WHATSAPP,
   Object.freeze({
-    scriptsShouldHaveManifestProp: false,
     checkLoggedInFromCookie: false,
     enforceCSPHeaders: false,
+    excludedPathnames: [],
     longTailIsLoadedConditionally: false,
+    scriptsShouldHaveManifestProp: false,
     useCompanyManifest: false,
   }),
 );


### PR DESCRIPTION
Fixes a regression caused by https://github.com/facebookincubator/meta-code-verify/pull/261 where `excludedPathnames` was missing:
- `excludedPathnames` is no longer optional.
- Resorted config definitions and entries to be alphabetical for easier reading.