### PR TITLE
Fix CV on WA

### DIFF
--- a/src/js/__tests__/contentUtils-test.js
+++ b/src/js/__tests__/contentUtils-test.js
@@ -43,6 +43,7 @@ describe('contentUtils', () => {
         },
         getAttribute: () => {},
         innerHTML: fakeInnerHtml,
+        src: '',
       };
       storeFoundJS(fakeScriptNode);
       expect(FOUND_SCRIPTS.get('version').length).toEqual(1);
@@ -92,7 +93,8 @@ describe('contentUtils', () => {
         childNodes: [],
         nodeName: 'SCRIPT',
         nodeType: 1,
-        tagName: 'div',
+        tagName: 'tagName',
+        src: '',
       };
       hasInvalidScripts(fakeElement);
       expect(FOUND_SCRIPTS.get('version').length).toBe(1);
@@ -172,6 +174,7 @@ describe('contentUtils', () => {
             nodeType: 1,
             childNodes: [],
             tagName: 'tagName',
+            src: '',
           },
         ],
         hasAttribute: () => {

--- a/src/js/contentUtils.ts
+++ b/src/js/contentUtils.ts
@@ -225,57 +225,62 @@ export function storeFoundJS(scriptNodeMaybe: HTMLScriptElement): void {
   let scriptDetails = null;
   let version = '';
 
-  if (
-    originConfig.scriptsShouldHaveManifestProp &&
-    (scriptNodeMaybe.src !== '' || scriptNodeMaybe.innerHTML !== '')
-  ) {
-    const dataBtManifest = scriptNodeMaybe.getAttribute('data-btmanifest');
-    if (dataBtManifest == null) {
-      // All src specified scripts should have a manifest atribution
-      updateCurrentState(
-        STATES.INVALID,
-        `No data-btmanifest attribute found on script ${scriptNodeMaybe.src}`,
-      );
-    }
+  if (scriptNodeMaybe.src !== '' || scriptNodeMaybe.innerHTML !== '') {
+    if (originConfig.scriptsShouldHaveManifestProp) {
+      const dataBtManifest = scriptNodeMaybe.getAttribute('data-btmanifest');
+      if (dataBtManifest == null) {
+        // All src specified scripts should have a manifest atribution
+        updateCurrentState(
+          STATES.INVALID,
+          `No data-btmanifest attribute found on script ${scriptNodeMaybe.src}`,
+        );
+      }
 
-    version = dataBtManifest.split('_')[0];
-    const otherType = dataBtManifest.split('_')[1];
-    scriptDetails = {
-      src: scriptNodeMaybe.src,
-      otherType,
-    };
-    ALL_FOUND_SCRIPT_TAGS.add(scriptNodeMaybe.src);
-  } else {
-    if (scriptNodeMaybe.src != null && scriptNodeMaybe.src !== '') {
+      version = dataBtManifest.split('_')[0];
+      const otherType = dataBtManifest.split('_')[1];
       scriptDetails = {
         src: scriptNodeMaybe.src,
-        otherType: currentFilterType,
+        otherType,
       };
       ALL_FOUND_SCRIPT_TAGS.add(scriptNodeMaybe.src);
     } else {
-      // no src, access innerHTML for the code
-      const hashLookupAttribute =
-        scriptNodeMaybe.attributes['data-binary-transparency-hash-key'];
-      const hashLookupKey = hashLookupAttribute && hashLookupAttribute.value;
-      scriptDetails = {
-        type: MESSAGE_TYPE.RAW_JS,
-        rawjs: scriptNodeMaybe.innerHTML,
-        lookupKey: hashLookupKey,
-        otherType: currentFilterType,
-      };
+      console.log(scriptNodeMaybe.src);
+      if (scriptNodeMaybe.src !== '') {
+        scriptDetails = {
+          src: scriptNodeMaybe.src,
+          otherType: currentFilterType,
+        };
+        ALL_FOUND_SCRIPT_TAGS.add(scriptNodeMaybe.src);
+      } else {
+        console.log(scriptNodeMaybe);
+        console.log(scriptNodeMaybe.innerHTML);
+        // no src, access innerHTML for the code
+        const hashLookupAttribute =
+          scriptNodeMaybe.attributes['data-binary-transparency-hash-key'];
+        const hashLookupKey = hashLookupAttribute && hashLookupAttribute.value;
+        scriptDetails = {
+          type: MESSAGE_TYPE.RAW_JS,
+          rawjs: scriptNodeMaybe.innerHTML,
+          lookupKey: hashLookupKey,
+          otherType: currentFilterType,
+        };
+        console.log(scriptDetails);
+      }
     }
-  }
 
-  if (FOUND_SCRIPTS.has(version)) {
-    FOUND_SCRIPTS.get(version).push(scriptDetails);
-  } else {
-    if (version != '') {
-      FOUND_SCRIPTS.set(version, [scriptDetails]);
+    if (FOUND_SCRIPTS.has(version)) {
+      FOUND_SCRIPTS.get(version).push(scriptDetails);
     } else {
-      FOUND_SCRIPTS.get(FOUND_SCRIPTS.keys().next().value).push(scriptDetails);
+      if (version != '') {
+        FOUND_SCRIPTS.set(version, [scriptDetails]);
+      } else {
+        FOUND_SCRIPTS.get(FOUND_SCRIPTS.keys().next().value).push(
+          scriptDetails,
+        );
+      }
     }
+    updateCurrentState(STATES.PROCESSING);
   }
-  updateCurrentState(STATES.PROCESSING);
 }
 
 function checkNodeForViolations(element: Element): void {

--- a/src/js/contentUtils.ts
+++ b/src/js/contentUtils.ts
@@ -286,7 +286,7 @@ function checkNodeForViolations(element: Element): void {
 
 export function hasInvalidScripts(scriptNodeMaybe: Node): void {
   // if not an HTMLElement ignore it!
-  if (scriptNodeMaybe.nodeType !== 1) {
+  if (scriptNodeMaybe.nodeType !== Node.ELEMENT_NODE) {
     return;
   }
 
@@ -319,7 +319,7 @@ export const scanForScripts = (): void => {
           Array.from(mutation.addedNodes).forEach(checkScript => {
             // Code within a script tag has changed
             if (
-              checkScript.nodeType === 3 &&
+              checkScript.nodeType === Node.TEXT_NODE &&
               mutation.target.nodeName.toLocaleLowerCase() === 'script'
             ) {
               hasInvalidScripts(mutation.target);
@@ -329,7 +329,7 @@ export const scanForScripts = (): void => {
           });
         } else if (
           mutation.type === 'attributes' &&
-          mutation.target.nodeType === 1
+          mutation.target.nodeType === Node.ELEMENT_NODE
         ) {
           checkNodeForViolations(mutation.target as Element);
         }

--- a/src/js/contentUtils.ts
+++ b/src/js/contentUtils.ts
@@ -244,7 +244,6 @@ export function storeFoundJS(scriptNodeMaybe: HTMLScriptElement): void {
       };
       ALL_FOUND_SCRIPT_TAGS.add(scriptNodeMaybe.src);
     } else {
-      console.log(scriptNodeMaybe.src);
       if (scriptNodeMaybe.src !== '') {
         scriptDetails = {
           src: scriptNodeMaybe.src,
@@ -252,8 +251,6 @@ export function storeFoundJS(scriptNodeMaybe: HTMLScriptElement): void {
         };
         ALL_FOUND_SCRIPT_TAGS.add(scriptNodeMaybe.src);
       } else {
-        console.log(scriptNodeMaybe);
-        console.log(scriptNodeMaybe.innerHTML);
         // no src, access innerHTML for the code
         const hashLookupAttribute =
           scriptNodeMaybe.attributes['data-binary-transparency-hash-key'];
@@ -264,7 +261,6 @@ export function storeFoundJS(scriptNodeMaybe: HTMLScriptElement): void {
           lookupKey: hashLookupKey,
           otherType: currentFilterType,
         };
-        console.log(scriptDetails);
       }
     }
 
@@ -321,7 +317,15 @@ export const scanForScripts = (): void => {
       mutationsList.forEach(mutation => {
         if (mutation.type === 'childList') {
           Array.from(mutation.addedNodes).forEach(checkScript => {
-            hasInvalidScripts(checkScript);
+            // Code within a script tag has changed
+            if (
+              checkScript.nodeType === 3 &&
+              mutation.target.nodeName.toLocaleLowerCase() === 'script'
+            ) {
+              hasInvalidScripts(mutation.target);
+            } else {
+              hasInvalidScripts(checkScript);
+            }
           });
         } else if (
           mutation.type === 'attributes' &&


### PR DESCRIPTION
Complimentary fix to https://github.com/facebookincubator/meta-code-verify/pull/264 for https://github.com/facebookincubator/meta-code-verify/issues/254

Ensure that if an empty script without a src is injected we do not store it for processing, if we later inject content into this script our Mutation Observers should now correctly detect and verify it.