### PR TITLE
Strictify

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,6 +16,10 @@
     "rules": {
         "@typescript-eslint/no-unused-vars": ["error", {"argsIgnorePattern": "^_"}],
         "@typescript-eslint/no-empty-function": 0,
-        "@typescript-eslint/no-extra-semi": 0
+        "@typescript-eslint/no-extra-semi": 0,
+        "@typescript-eslint/ban-ts-comment": [
+            "error",
+            {"ts-ignore": "allow-with-description"}
+        ]
     }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist/*
 node_modules
 .DS_Store
+.yarn/

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,3 @@
+nodeLinker: node-modules
+
+yarnPath: .yarn/releases/yarn-1.22.19.cjs

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,0 @@
-nodeLinker: node-modules
-
-yarnPath: .yarn/releases/yarn-1.22.19.cjs

--- a/build/rollup-plugin-clean-once.ts
+++ b/build/rollup-plugin-clean-once.ts
@@ -39,7 +39,7 @@ export default function rollupPluginCleanOnce(): Plugin {
       const rootDir = process.cwd();
       const dirToDelete = options.dir
         ? path.resolve(rootDir, options.dir)
-        : path.dirname(path.resolve(rootDir, options.file));
+        : path.dirname(path.resolve(rootDir, options.file!));
       // Only delete once.
       if (deletedDirs.has(dirToDelete)) {
         return;

--- a/build/utils.ts
+++ b/build/utils.ts
@@ -12,7 +12,7 @@ export async function readDirRecursive(
   dirPath: string,
 ): Promise<Array<string>> {
   const fileNames = await fs.readdir(dirPath);
-  const files = [];
+  const files: string[] = [];
   await Promise.all(
     fileNames.map(async fileName => {
       const stats = await fs.stat(path.resolve(dirPath, fileName));

--- a/package.json
+++ b/package.json
@@ -33,6 +33,5 @@
     "ts-jest": "^29.0.0",
     "tslib": "^2.5.0",
     "typescript": "^5.2.2"
-  },
-  "packageManager": "yarn@1.22.19"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -19,12 +19,12 @@
     "test": "node --experimental-vm-modules --no-warnings node_modules/jest/bin/jest.js"
   },
   "devDependencies": {
-    "@rollup/plugin-eslint": "^9.0.3",
-    "@rollup/plugin-typescript": "^11.0.0",
-    "@types/chrome": "^0.0.213",
+    "@rollup/plugin-eslint": "^9.0.5",
+    "@rollup/plugin-typescript": "^11.1.5",
+    "@types/chrome": "^0.0.248",
     "@types/jest": "^29.4.0",
-    "@typescript-eslint/eslint-plugin": "^5.52.0",
-    "@typescript-eslint/parser": "^5.52.0",
+    "@typescript-eslint/eslint-plugin": "^6.8.0",
+    "@typescript-eslint/parser": "^6.8.0",
     "eslint": "^7.32.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.0.0",
@@ -32,6 +32,7 @@
     "rollup": "^2.56.3",
     "ts-jest": "^29.0.0",
     "tslib": "^2.5.0",
-    "typescript": "^4.9.5"
-  }
+    "typescript": "^5.2.2"
+  },
+  "packageManager": "yarn@1.22.19"
 }

--- a/src/js/__tests__/checkDocumentCSPHeaders-test.js
+++ b/src/js/__tests__/checkDocumentCSPHeaders-test.js
@@ -10,10 +10,12 @@
 import {jest} from '@jest/globals';
 import {checkDocumentCSPHeaders} from '../content/checkDocumentCSPHeaders';
 import {ORIGIN_TYPE} from '../config';
+import {setCurrentOrigin} from '../content/updateCurrentState';
 
 describe('checkDocumentCSPHeaders', () => {
   beforeEach(() => {
     window.chrome.runtime.sendMessage = jest.fn(() => {});
+    setCurrentOrigin('FACEBOOK');
   });
   describe('Enforce precedence', () => {
     it('Enforce valid policy from script-src', () => {

--- a/src/js/__tests__/checkDocumentCSPHeaders-test.js
+++ b/src/js/__tests__/checkDocumentCSPHeaders-test.js
@@ -42,27 +42,29 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeTruthy();
     });
     it('Enforce invalid due to script-src, missing Report policy', () => {
-      const isValid = checkDocumentCSPHeaders(
-        [
-          `default-src data: blob: 'self' *.facebook.com *.fbcdn.net;` +
-            `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';` +
-            'worker-src *.facebook.com/worker_url;',
-        ],
-        [],
-        ORIGIN_TYPE.FACEBOOK,
-      );
-      expect(isValid).toBeFalsy();
+      expect(() =>
+        checkDocumentCSPHeaders(
+          [
+            `default-src data: blob: 'self' *.facebook.com *.fbcdn.net;` +
+              `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';` +
+              'worker-src *.facebook.com/worker_url;',
+          ],
+          [],
+          ORIGIN_TYPE.FACEBOOK,
+        ),
+      ).toThrow(new Error('Missing CSP report-only header'));
     });
     it('Enforce invalid due to default-src, missing Report policy', () => {
-      const isValid = checkDocumentCSPHeaders(
-        [
-          `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'unsafe-eval';` +
-            'worker-src *.facebook.com/worker_url;',
-        ],
-        [],
-        ORIGIN_TYPE.FACEBOOK,
-      );
-      expect(isValid).toBeFalsy();
+      expect(() =>
+        checkDocumentCSPHeaders(
+          [
+            `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'unsafe-eval';` +
+              'worker-src *.facebook.com/worker_url;',
+          ],
+          [],
+          ORIGIN_TYPE.FACEBOOK,
+        ),
+      ).toThrow(new Error('Missing CSP report-only header'));
     });
   });
   describe('Report affecting outcome', () => {
@@ -86,25 +88,27 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeTruthy();
     });
     it('Enforce invalid, incorrect Report policy because of script-src', () => {
-      const isValid = checkDocumentCSPHeaders(
-        ['worker-src *.facebook.com/worker_url;'],
-        [
-          `default-src data: blob: 'self' *.facebook.com *.fbcdn.net;` +
-            `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
-        ],
-        ORIGIN_TYPE.FACEBOOK,
-      );
-      expect(isValid).toBeFalsy();
+      expect(() =>
+        checkDocumentCSPHeaders(
+          ['worker-src *.facebook.com/worker_url;'],
+          [
+            `default-src data: blob: 'self' *.facebook.com *.fbcdn.net;` +
+              `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
+          ],
+          ORIGIN_TYPE.FACEBOOK,
+        ),
+      ).toThrow(new Error('Missing unsafe-eval from CSP report-only header'));
     });
     it('Enforce invalid, incorrect Report policy because of default-src', () => {
-      const isValid = checkDocumentCSPHeaders(
-        ['worker-src *.facebook.com/worker_url;'],
-        [
-          `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'unsafe-eval';`,
-        ],
-        ORIGIN_TYPE.FACEBOOK,
-      );
-      expect(isValid).toBeFalsy();
+      expect(() =>
+        checkDocumentCSPHeaders(
+          ['worker-src *.facebook.com/worker_url;'],
+          [
+            `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'unsafe-eval';`,
+          ],
+          ORIGIN_TYPE.FACEBOOK,
+        ),
+      ).toThrow(new Error('Missing unsafe-eval from CSP report-only header'));
     });
   });
   describe('Multiple policies, enforcement', () => {
@@ -169,27 +173,29 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeTruthy();
     });
     it('Should be invalid if policy with precedence is not enforcing, script-src precedence', () => {
-      const isValid = checkDocumentCSPHeaders(
-        [
-          `default-src *.facebook.com;`,
-          `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
-        ],
-        [],
-        ORIGIN_TYPE.FACEBOOK,
-      );
-      expect(isValid).toBeFalsy();
+      expect(() =>
+        checkDocumentCSPHeaders(
+          [
+            `default-src *.facebook.com;`,
+            `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
+          ],
+          [],
+          ORIGIN_TYPE.FACEBOOK,
+        ),
+      ).toThrow(new Error('Missing CSP report-only header'));
     });
     it('Should be invalid if none of the policies are enforcing, script-src precedence', () => {
-      const isValid = checkDocumentCSPHeaders(
-        [
-          `default-src *.facebook.com;` +
-            `script-src *.facebook.com 'unsafe-eval';`,
-          `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
-        ],
-        [],
-        ORIGIN_TYPE.FACEBOOK,
-      );
-      expect(isValid).toBeFalsy();
+      expect(() =>
+        checkDocumentCSPHeaders(
+          [
+            `default-src *.facebook.com;` +
+              `script-src *.facebook.com 'unsafe-eval';`,
+            `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
+          ],
+          [],
+          ORIGIN_TYPE.FACEBOOK,
+        ),
+      ).toThrow(new Error('Missing CSP report-only header'));
     });
     it('Should be invalid if valid policies but missing worker-src', () => {
       const isValid = checkDocumentCSPHeaders(
@@ -254,27 +260,29 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeTruthy();
     });
     it('Should be invalid if policy with precedence is not reporting, script-src precedence', () => {
-      const isValid = checkDocumentCSPHeaders(
-        [],
-        [
-          `default-src *.facebook.com;`,
-          `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
-        ],
-        ORIGIN_TYPE.FACEBOOK,
-      );
-      expect(isValid).toBeFalsy();
+      expect(() =>
+        checkDocumentCSPHeaders(
+          [],
+          [
+            `default-src *.facebook.com;`,
+            `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
+          ],
+          ORIGIN_TYPE.FACEBOOK,
+        ),
+      ).toThrow(new Error('Missing unsafe-eval from CSP report-only header'));
     });
     it('Should be invalid if none of the policies are reporting, script-src precedence', () => {
-      const isValid = checkDocumentCSPHeaders(
-        [],
-        [
-          `default-src *.facebook.com;` +
-            `script-src *.facebook.com 'unsafe-eval';`,
-          `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
-        ],
-        ORIGIN_TYPE.FACEBOOK,
-      );
-      expect(isValid).toBeFalsy();
+      expect(() =>
+        checkDocumentCSPHeaders(
+          [],
+          [
+            `default-src *.facebook.com;` +
+              `script-src *.facebook.com 'unsafe-eval';`,
+            `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
+          ],
+          ORIGIN_TYPE.FACEBOOK,
+        ),
+      ).toThrow(new Error('Missing unsafe-eval from CSP report-only header'));
     });
   });
   describe('Worker CSP', () => {

--- a/src/js/__tests__/checkElementForViolatingAttributes-test.js
+++ b/src/js/__tests__/checkElementForViolatingAttributes-test.js
@@ -8,8 +8,12 @@
 'use strict';
 
 import {checkElementForViolatingAttributes} from '../content/checkElementForViolatingAttributes';
+import {setCurrentOrigin} from '../content/updateCurrentState';
 
 describe('contentUtils', () => {
+  beforeEach(() => {
+    setCurrentOrigin('FACEBOOK');
+  });
   describe('checkElementForViolatingAttributes', () => {
     it('should not execute if element has no attributes', () => {
       // no hasAttribute function

--- a/src/js/__tests__/checkWorkerEndpointCSP-test.js
+++ b/src/js/__tests__/checkWorkerEndpointCSP-test.js
@@ -10,6 +10,7 @@
 import {jest} from '@jest/globals';
 import {checkWorkerEndpointCSP} from '../content/checkWorkerEndpointCSP';
 import {ORIGIN_TYPE} from '../config';
+import {setCurrentOrigin} from '../content/updateCurrentState';
 
 const CSP_KEY = 'content-security-policy';
 const CSPRO_KEY = 'content-security-policy-report-only';
@@ -17,6 +18,7 @@ const CSPRO_KEY = 'content-security-policy-report-only';
 describe('checkWorkerEndpointCSP', () => {
   beforeEach(() => {
     window.chrome.runtime.sendMessage = jest.fn(() => {});
+    setCurrentOrigin('FACEBOOK');
   });
   it('Invalid if no CSP headers on Worker script', () => {
     expect(

--- a/src/js/__tests__/checkWorkerEndpointCSP-test.js
+++ b/src/js/__tests__/checkWorkerEndpointCSP-test.js
@@ -21,7 +21,7 @@ describe('checkWorkerEndpointCSP', () => {
     setCurrentOrigin('FACEBOOK');
   });
   it('Invalid if no CSP headers on Worker script', () => {
-    expect(
+    expect(() =>
       checkWorkerEndpointCSP(
         {
           responseHeaders: [],
@@ -29,10 +29,10 @@ describe('checkWorkerEndpointCSP', () => {
         [new Set()],
         ORIGIN_TYPE.FACEBOOK,
       ),
-    ).toBeFalsy();
+    ).toThrow(new Error('Missing CSP report-only header'));
   });
   it('Invalid if empty CSP headers on Worker script', () => {
-    expect(
+    expect(() =>
       checkWorkerEndpointCSP(
         {
           responseHeaders: [
@@ -43,14 +43,14 @@ describe('checkWorkerEndpointCSP', () => {
         [new Set()],
         ORIGIN_TYPE.FACEBOOK,
       ),
-    ).toBeFalsy();
+    ).toThrow(new Error('Missing CSP report-only header'));
   });
   /**
    * Evals covered more extensively by checkDocumentCSPHeaders
    * Same logic is used for both CSPs
    */
   it('Invalid if eval allowed by CSP', () => {
-    expect(
+    expect(() =>
       checkWorkerEndpointCSP(
         {
           responseHeaders: [
@@ -67,7 +67,7 @@ describe('checkWorkerEndpointCSP', () => {
         [new Set(['*.facebook.com/worker_url'])],
         ORIGIN_TYPE.FACEBOOK,
       ),
-    ).toBeFalsy();
+    ).toThrow(new Error('Missing CSP report-only header'));
   });
   it('Invalid if blob: allowed by script src', () => {
     expect(

--- a/src/js/__tests__/contentUtils-test.js
+++ b/src/js/__tests__/contentUtils-test.js
@@ -14,13 +14,16 @@ import {
   scanForScripts,
   FOUND_SCRIPTS,
   storeFoundJS,
+  UNINITIALIZED,
 } from '../contentUtils';
+import {setCurrentOrigin} from '../content/updateCurrentState';
 
 describe('contentUtils', () => {
   beforeEach(() => {
     window.chrome.runtime.sendMessage = jest.fn(() => {});
+    setCurrentOrigin('FACEBOOK');
     FOUND_SCRIPTS.clear();
-    FOUND_SCRIPTS.set('version', []);
+    FOUND_SCRIPTS.set(UNINITIALIZED, []);
   });
   describe('storeFoundJS', () => {
     it('should handle scripts with src correctly', () => {
@@ -30,8 +33,8 @@ describe('contentUtils', () => {
         getAttribute: () => {},
       };
       storeFoundJS(fakeScriptNode);
-      expect(FOUND_SCRIPTS.get('version').length).toEqual(1);
-      expect(FOUND_SCRIPTS.get('version')[0].src).toEqual(fakeUrl);
+      expect(FOUND_SCRIPTS.get(UNINITIALIZED).length).toEqual(1);
+      expect(FOUND_SCRIPTS.get(UNINITIALIZED)[0].src).toEqual(fakeUrl);
       expect(window.chrome.runtime.sendMessage.mock.calls.length).toBe(1);
     });
     it('should handle inline scripts correctly', () => {
@@ -46,9 +49,11 @@ describe('contentUtils', () => {
         src: '',
       };
       storeFoundJS(fakeScriptNode);
-      expect(FOUND_SCRIPTS.get('version').length).toEqual(1);
-      expect(FOUND_SCRIPTS.get('version')[0].rawjs).toEqual(fakeInnerHtml);
-      expect(FOUND_SCRIPTS.get('version')[0].lookupKey).toEqual(fakeLookupKey);
+      expect(FOUND_SCRIPTS.get(UNINITIALIZED).length).toEqual(1);
+      expect(FOUND_SCRIPTS.get(UNINITIALIZED)[0].rawjs).toEqual(fakeInnerHtml);
+      expect(FOUND_SCRIPTS.get(UNINITIALIZED)[0].lookupKey).toEqual(
+        fakeLookupKey,
+      );
       expect(window.chrome.runtime.sendMessage.mock.calls.length).toBe(1);
     });
     it('should send update icon message if valid', () => {
@@ -97,8 +102,10 @@ describe('contentUtils', () => {
         src: '',
       };
       hasInvalidScripts(fakeElement);
-      expect(FOUND_SCRIPTS.get('version').length).toBe(1);
-      expect(FOUND_SCRIPTS.get('version')[0].type).toBe(MESSAGE_TYPE.RAW_JS);
+      expect(FOUND_SCRIPTS.get(UNINITIALIZED).length).toBe(1);
+      expect(FOUND_SCRIPTS.get(UNINITIALIZED)[0].type).toBe(
+        MESSAGE_TYPE.RAW_JS,
+      );
       expect(window.chrome.runtime.sendMessage.mock.calls.length).toBe(1);
       expect(window.chrome.runtime.sendMessage.mock.calls[0][0].type).toBe(
         MESSAGE_TYPE.UPDATE_STATE,
@@ -142,7 +149,7 @@ describe('contentUtils', () => {
         tagName: 'tagName',
       };
       hasInvalidScripts(fakeElement);
-      expect(FOUND_SCRIPTS.get('version').length).toBe(0);
+      expect(FOUND_SCRIPTS.get(UNINITIALIZED).length).toBe(0);
       expect(window.chrome.runtime.sendMessage.mock.calls.length).toBe(0);
     });
     it('should store any script element direct children', () => {
@@ -185,8 +192,10 @@ describe('contentUtils', () => {
         tagName: 'tagName',
       };
       hasInvalidScripts(fakeElement);
-      expect(FOUND_SCRIPTS.get('version').length).toBe(1);
-      expect(FOUND_SCRIPTS.get('version')[0].type).toBe(MESSAGE_TYPE.RAW_JS);
+      expect(FOUND_SCRIPTS.get(UNINITIALIZED).length).toBe(1);
+      expect(FOUND_SCRIPTS.get(UNINITIALIZED)[0].type).toBe(
+        MESSAGE_TYPE.RAW_JS,
+      );
       expect(window.chrome.runtime.sendMessage.mock.calls.length).toBe(1);
       expect(window.chrome.runtime.sendMessage.mock.calls[0][0].type).toBe(
         MESSAGE_TYPE.UPDATE_STATE,
@@ -256,7 +265,7 @@ describe('contentUtils', () => {
         tagName: 'tagName',
       };
       hasInvalidScripts(fakeElement);
-      expect(FOUND_SCRIPTS.get('version').length).toBe(2);
+      expect(FOUND_SCRIPTS.get(UNINITIALIZED).length).toBe(2);
       expect(window.chrome.runtime.sendMessage.mock.calls.length).toBe(2);
     });
   });

--- a/src/js/background.ts
+++ b/src/js/background.ts
@@ -11,7 +11,6 @@ import {MESSAGE_TYPE, ORIGIN_HOST, ORIGIN_TIMEOUT} from './config';
 import {
   recordContentScriptStart,
   updateContentScriptState,
-  invalidateContentScriptStateAndThrow,
 } from './background/tab_state_tracker/tabStateTracker';
 import setupCSPListener from './background/setupCSPListener';
 import setUpWebRequestsListener from './background/setUpWebRequestsListener';
@@ -226,16 +225,6 @@ function handleMessages(
         });
 
         return;
-      }
-
-      const cspHeadersByTab = CSP_HEADERS.get(validSender.tab.id);
-      if (!cspHeadersByTab) {
-        // This may indicate that setupCSPListener has failed to fire.
-        invalidateContentScriptStateAndThrow(
-          validSender,
-          message.origin,
-          'No CSP headers have been stored for this tab ID',
-        );
       }
 
       sendResponse({

--- a/src/js/background.ts
+++ b/src/js/background.ts
@@ -240,7 +240,6 @@ function handleMessages(
 
       sendResponse({
         success: true,
-        // eslint-disable-next-line
         cspHeaders: CSP_HEADERS.get(validSender.tab.id)?.get(
           validSender.frameId,
         ),

--- a/src/js/background.ts
+++ b/src/js/background.ts
@@ -11,12 +11,15 @@ import {MESSAGE_TYPE, ORIGIN_HOST, ORIGIN_TIMEOUT} from './config';
 import {
   recordContentScriptStart,
   updateContentScriptState,
+  invalidateContentScriptStateAndThrow,
 } from './background/tab_state_tracker/tabStateTracker';
 import setupCSPListener from './background/setupCSPListener';
 import setUpWebRequestsListener from './background/setUpWebRequestsListener';
 import {validateMetaCompanyManifest} from './background/validateMetaCompanyManifest';
 import {validateManifest} from './background/validateManifest';
+import {validateSender} from './background/validateSender';
 import {MessagePayload, MessageResponse} from './shared/MessageTypes';
+import {setOrUpdateSetInMap} from './shared/nestedDataHelpers';
 
 const MANIFEST_CACHE = new Map<Origin, Map<string, Manifest>>();
 
@@ -64,14 +67,18 @@ function logReceivedMessage(
       if (message.state === STATES.INVALID) {
         logger = console.error;
       } else if (message.state === STATES.PROCESSING) {
-        logger = null;
+        logger = () => {};
       }
       break;
     case MESSAGE_TYPE.DEBUG:
       logger = console.debug;
       break;
   }
-  logger?.(`handleMessages from tab:${sender.tab.id}`, message);
+  if (sender.tab) {
+    logger(`handleMessages from tab:${sender.tab.id}`, JSON.stringify(message));
+  } else {
+    logger(`handleMessages from unknown tab`, message);
+  }
 }
 
 function handleMessages(
@@ -80,9 +87,25 @@ function handleMessages(
   sendResponse: (_: MessageResponse) => void,
 ): void | boolean {
   logReceivedMessage(message, sender);
-  if (message.type == MESSAGE_TYPE.LOAD_MANIFEST) {
-    // validate manifest
-    if (message.useCompanyManifest) {
+  const validSender = validateSender(sender);
+
+  // There are niche reasons we might receive messages from an unexpected
+  // sender (see validateSender method for details). Our own messages should
+  // never fall into this category, so we can simply ignore them.
+  if (!validSender) {
+    return;
+  }
+
+  switch (message.type) {
+    // Log only
+    case MESSAGE_TYPE.DEBUG:
+      return;
+
+    // Log only
+    case MESSAGE_TYPE.STATE_UPDATED:
+      return;
+
+    case MESSAGE_TYPE.LOAD_COMPANY_MANIFEST: {
       validateMetaCompanyManifest(
         message.rootHash,
         message.otherHashes,
@@ -92,13 +115,12 @@ function handleMessages(
       ).then(validationResult => {
         if (validationResult.valid) {
           const manifestMap = getManifestMapForOrigin(message.origin);
-          let manifest = manifestMap.get(message.version);
-          if (!manifest) {
-            manifest = {
-              leaves: [],
-              root: message.rootHash,
-              start: Date.now(),
-            };
+          const manifest = manifestMap.get(message.version) ?? {
+            leaves: [],
+            root: message.rootHash,
+            start: Date.now(),
+          };
+          if (!manifestMap.has(message.version)) {
             manifestMap.set(message.version, manifest);
           }
           message.leaves.forEach(leaf => {
@@ -111,7 +133,12 @@ function handleMessages(
           sendResponse(validationResult);
         }
       });
-    } else {
+
+      // Indicates that the message will send an async response.
+      return true;
+    }
+
+    case MESSAGE_TYPE.LOAD_MANIFEST: {
       const slicedHash = message.rootHash.slice(2);
       const slicedLeaves = message.leaves.map(leaf => {
         return leaf.slice(2);
@@ -135,67 +162,108 @@ function handleMessages(
           sendResponse(validationResult);
         }
       });
-    }
-    return true;
-  } else if (message.type == MESSAGE_TYPE.RAW_JS) {
-    const origin = MANIFEST_CACHE.get(message.origin);
-    if (!origin) {
-      sendResponse({valid: false, reason: 'no matching origin'});
-      return;
-    }
-    const manifestObj = origin.get(message.version);
-    const manifest = manifestObj && manifestObj.leaves;
-    if (!manifest) {
-      sendResponse({valid: false, reason: 'no matching manifest'});
-      return;
+
+      // Indicates that the message will send an async response.
+      return true;
     }
 
-    // fetch the src
-    const encoder = new TextEncoder();
-    const encodedJS = encoder.encode(message.rawjs);
-    // hash the src
-    crypto.subtle.digest('SHA-256', encodedJS).then(jsHashBuffer => {
-      const jsHashArray = Array.from(new Uint8Array(jsHashBuffer));
-      const jsHash = jsHashArray
-        .map(b => b.toString(16).padStart(2, '0'))
-        .join('');
-
-      if (manifestObj.leaves.includes(jsHash)) {
-        sendResponse({valid: true});
-      } else {
-        sendResponse({
-          valid: false,
-          hash: jsHash,
-          reason:
-            'Error: hash does not match ' +
-            message.origin +
-            ', ' +
-            message.version +
-            ', unmatched JS is ' +
-            message.rawjs,
-        });
+    case MESSAGE_TYPE.RAW_JS: {
+      const origin = MANIFEST_CACHE.get(message.origin);
+      if (!origin) {
+        sendResponse({valid: false, reason: 'no matching origin'});
+        return;
       }
-    });
-    return true;
-  } else if (message.type === MESSAGE_TYPE.UPDATE_STATE) {
-    updateContentScriptState(sender, message.state, message.origin);
-    sendResponse({success: true});
-  } else if (message.type === MESSAGE_TYPE.CONTENT_SCRIPT_START) {
-    recordContentScriptStart(sender, message.origin);
-    sendResponse({
-      success: true,
-      cspHeaders: CSP_HEADERS?.get(sender.tab.id)?.get(sender.frameId),
-      cspReportHeaders: CSP_REPORT_HEADERS?.get(sender.tab.id)?.get(
-        sender.frameId,
-      ),
-    });
-  } else if (message.type === MESSAGE_TYPE.UPDATED_CACHED_SCRIPT_URLS) {
-    if (!CACHED_SCRIPTS_URLS.has(sender.tab.id)) {
-      CACHED_SCRIPTS_URLS.set(sender.tab.id, new Set());
+      const manifestObj = origin.get(message.version);
+      const manifest = manifestObj && manifestObj.leaves;
+      if (!manifest) {
+        sendResponse({valid: false, reason: 'no matching manifest'});
+        return;
+      }
+
+      // fetch the src
+      const encoder = new TextEncoder();
+      const encodedJS = encoder.encode(message.rawjs);
+      // hash the src
+      crypto.subtle.digest('SHA-256', encodedJS).then(jsHashBuffer => {
+        const jsHashArray = Array.from(new Uint8Array(jsHashBuffer));
+        const jsHash = jsHashArray
+          .map(b => b.toString(16).padStart(2, '0'))
+          .join('');
+
+        if (manifestObj.leaves.includes(jsHash)) {
+          sendResponse({valid: true, hash: jsHash});
+        } else {
+          sendResponse({
+            valid: false,
+            hash: jsHash,
+            reason:
+              'Error: hash does not match ' +
+              message.origin +
+              ', ' +
+              message.version +
+              ', unmatched JS is ' +
+              message.rawjs,
+          });
+        }
+      });
+
+      // Indicates that the message will send an async response.
+      return true;
     }
-    CACHED_SCRIPTS_URLS.get(sender.tab.id).add(message.url);
-    sendResponse({success: true});
-    return true;
+
+    case MESSAGE_TYPE.UPDATE_STATE: {
+      updateContentScriptState(validSender, message.state, message.origin);
+      sendResponse({success: true});
+      return;
+    }
+
+    case MESSAGE_TYPE.CONTENT_SCRIPT_START: {
+      recordContentScriptStart(validSender, message.origin);
+
+      if (!message.checkCSPHeaders) {
+        sendResponse({
+          success: true,
+        });
+
+        return;
+      }
+
+      const cspHeadersByTab = CSP_HEADERS.get(validSender.tab.id);
+      if (!cspHeadersByTab) {
+        // This may indicate that setupCSPListener has failed to fire.
+        invalidateContentScriptStateAndThrow(
+          validSender,
+          message.origin,
+          'No CSP headers have been stored for this tab ID',
+        );
+      }
+
+      sendResponse({
+        success: true,
+        // eslint-disable-next-line
+        cspHeaders: CSP_HEADERS.get(validSender.tab.id)?.get(
+          validSender.frameId,
+        ),
+        cspReportHeaders: CSP_REPORT_HEADERS?.get(validSender.tab.id)?.get(
+          validSender.frameId,
+        ),
+      });
+
+      return;
+    }
+
+    case MESSAGE_TYPE.UPDATED_CACHED_SCRIPT_URLS: {
+      setOrUpdateSetInMap(CACHED_SCRIPTS_URLS, validSender.tab.id, message.url);
+      sendResponse({success: true});
+
+      return true;
+    }
+
+    default: {
+      // See: https://www.typescriptlang.org/docs/handbook/2/narrowing.html#exhaustiveness-checking
+      const _exhaustiveCheck: never = message;
+      return _exhaustiveCheck;
+    }
   }
 }
 

--- a/src/js/background/setupCSPListener.ts
+++ b/src/js/background/setupCSPListener.ts
@@ -7,6 +7,7 @@
 
 import {CSPHeaderMap} from '../background';
 import {getCSPHeadersFromWebRequestResponse} from '../shared/getCSPHeadersFromWebRequestResponse';
+import {setOrUpdateMapInMap} from '../shared/nestedDataHelpers';
 
 export default function setupCSPListener(
   cspHeadersMap: CSPHeaderMap,
@@ -21,11 +22,11 @@ export default function setupCSPListener(
           true,
         );
         let frameId = details.frameId;
-        const detailsUntyped = details as any;
-        // Missing type definitions in @types/chrome
         if (
-          detailsUntyped?.documentLifecycle === 'prerender' &&
-          detailsUntyped?.frameType === 'outermost_frame' &&
+          // @ts-expect-error Missing: type definitions in @types/chrome
+          details?.documentLifecycle === 'prerender' &&
+          // @ts-expect-error Missing: type definitions in @types/chrome
+          details?.frameType === 'outermost_frame' &&
           details.type === 'main_frame' &&
           details.frameId !== 0
         ) {
@@ -36,17 +37,15 @@ export default function setupCSPListener(
            */
           frameId = 0;
         }
-        if (!cspHeadersMap.has(details.tabId)) {
-          cspHeadersMap.set(details.tabId, new Map());
-        }
-        if (!cspReportHeadersMap.has(details.tabId)) {
-          cspReportHeadersMap.set(details.tabId, new Map());
-        }
-        cspHeadersMap.get(details.tabId).set(
+        setOrUpdateMapInMap(
+          cspHeadersMap,
+          details.tabId,
           frameId,
           cspHeaders.map(h => h.value),
         );
-        cspReportHeadersMap.get(details.tabId).set(
+        setOrUpdateMapInMap(
+          cspReportHeadersMap,
+          details.tabId,
           frameId,
           cspReportHeaders.map(h => h.value),
         );

--- a/src/js/background/tab_state_tracker/StateMachine.ts
+++ b/src/js/background/tab_state_tracker/StateMachine.ts
@@ -12,9 +12,9 @@ import {State, STATES} from '../../config';
 //   (a) a boolean indicating if the transition to that state is valid
 //   (b) another state to transition to should a transition to the 'from' state
 //       is attempted.
-const STATE_TRANSITIONS: Partial<{
+const STATE_TRANSITIONS: {
   [key in State]: Partial<{[key in State]: boolean | State}>;
-}> = {
+} = {
   [STATES.START]: {
     [STATES.START]: true,
     [STATES.PROCESSING]: true,

--- a/src/js/background/tab_state_tracker/TabStateMachine.ts
+++ b/src/js/background/tab_state_tracker/TabStateMachine.ts
@@ -53,6 +53,7 @@ export default class TabStateMachine extends StateMachine {
 
   updateStateForFrame(frameId: number, newState: State): void {
     if (!(frameId in this._frameStates)) {
+      this._frameStates[frameId].updateStateIfValid('INVALID');
       throw new Error(
         `State machine for frame: ${frameId} does not exist for tab: ${this._tabId}`,
       );

--- a/src/js/background/tab_state_tracker/tabStateTracker.ts
+++ b/src/js/background/tab_state_tracker/tabStateTracker.ts
@@ -47,15 +47,3 @@ export function updateContentScriptState(
     newState,
   );
 }
-
-export function invalidateContentScriptStateAndThrow(
-  sender: ValidSender,
-  origin: Origin,
-  error: string,
-): never {
-  getOrCreateTabStateMachine(sender.tab.id, origin).updateStateForFrame(
-    sender.frameId,
-    'INVALID',
-  );
-  throw new Error(error);
-}

--- a/src/js/background/tab_state_tracker/tabStateTracker.ts
+++ b/src/js/background/tab_state_tracker/tabStateTracker.ts
@@ -7,6 +7,7 @@
 
 import {Origin, State} from '../../config';
 import TabStateMachine from './TabStateMachine';
+import {ValidSender} from '../validateSender';
 
 const tabStateTracker = new Map<number, TabStateMachine>();
 
@@ -18,16 +19,15 @@ chrome.tabs.onReplaced.addListener((_addedTabId, removedTabId: number) => {
 });
 
 function getOrCreateTabStateMachine(tabId: number, origin: Origin) {
+  const tabState =
+    tabStateTracker.get(tabId) ?? new TabStateMachine(tabId, origin);
   if (!tabStateTracker.has(tabId)) {
-    tabStateTracker.set(tabId, new TabStateMachine(tabId, origin));
+    tabStateTracker.set(tabId, tabState);
   }
-  return tabStateTracker.get(tabId);
+  return tabState;
 }
 
-export function recordContentScriptStart(
-  sender: chrome.runtime.MessageSender,
-  origin: Origin,
-) {
+export function recordContentScriptStart(sender: ValidSender, origin: Origin) {
   // This is a top-level frame initializing
   if (sender.frameId === 0) {
     tabStateTracker.delete(sender.tab.id);
@@ -38,7 +38,7 @@ export function recordContentScriptStart(
 }
 
 export function updateContentScriptState(
-  sender: chrome.runtime.MessageSender,
+  sender: ValidSender,
   newState: State,
   origin: Origin,
 ) {
@@ -46,4 +46,16 @@ export function updateContentScriptState(
     sender.frameId,
     newState,
   );
+}
+
+export function invalidateContentScriptStateAndThrow(
+  sender: ValidSender,
+  origin: Origin,
+  error: string,
+): never {
+  getOrCreateTabStateMachine(sender.tab.id, origin).updateStateForFrame(
+    sender.frameId,
+    'INVALID',
+  );
+  throw new Error(error);
 }

--- a/src/js/background/validateManifest.ts
+++ b/src/js/background/validateManifest.ts
@@ -8,7 +8,7 @@
 import {getCFRootHash} from './getCFRootHash';
 
 const fromHexString = (hexString: string): Uint8Array =>
-  new Uint8Array(hexString.match(/.{1,2}/g).map(byte => parseInt(byte, 16)));
+  new Uint8Array(hexString.match(/.{1,2}/g)!.map(byte => parseInt(byte, 16)));
 
 const toHexString = (bytes: Uint8Array): string =>
   bytes.reduce((str, byte) => str + byte.toString(16).padStart(2, '0'), '');
@@ -63,7 +63,7 @@ export async function validateManifest(
     leaf => fromHexString(leaf.replace('0x', '')).buffer,
   );
   let newhashes = [];
-  let bonus: ArrayBufferLike = null;
+  let bonus: ArrayBufferLike | null = null;
 
   while (oldhashes.length > 1) {
     for (let index = 0; index < oldhashes.length; index += 2) {

--- a/src/js/background/validateSender.ts
+++ b/src/js/background/validateSender.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export type ValidSender = {
+  frameId: number;
+  tab: {
+    id: number;
+  };
+};
+
+export function validateSender(
+  sender: chrome.runtime.MessageSender,
+): ValidSender | undefined {
+  // The declaration for `sender.tab`:
+  // The tabs.Tab which opened the connection, if any. This property will only
+  // be present when the connection was opened from a tab (including content
+  // scripts), and only if the receiver is an extension, not an app.
+  //
+  // We will always be receiving this message in an extension, and always from
+  // a tab. Thus receiving a message without a tab indicates something wrong.
+  const tab = sender.tab!;
+  if (!tab) {
+    return;
+  }
+
+  // The declaration for `tab.id`:
+  // The ID of the tab. Tab IDs are unique within a browser session. Under some
+  // circumstances a Tab may not be assigned an ID, for example when querying
+  // foreign tabs using the sessions API, in which case a session ID may be
+  // present. Tab ID can also be set to chrome.tabs.TAB_ID_NONE for apps and
+  // devtools windows.
+  //
+  // Since none of these apply we can assume that a missing ID indicates something
+  // has gone wrong.
+  const tabId = tab.id;
+  if (tabId === undefined) {
+    return;
+  }
+
+  // If a tab is present, a frameId should always be present.
+  const frameId = sender.frameId;
+  if (frameId === undefined) {
+    return;
+  }
+
+  return {
+    frameId: frameId!,
+    tab: {
+      id: tabId,
+    },
+  };
+}

--- a/src/js/config.ts
+++ b/src/js/config.ts
@@ -91,6 +91,7 @@ export const KNOWN_EXTENSION_HASHES = [
 
 export const MESSAGE_TYPE = Object.freeze({
   DEBUG: 'DEBUG',
+  LOAD_COMPANY_MANIFEST: 'LOAD_COMPANY_MANIFEST',
   LOAD_MANIFEST: 'LOAD_MANIFEST',
   POPUP_STATE: 'POPUP_STATE',
   RAW_JS: 'RAW_JS',
@@ -102,7 +103,7 @@ export const MESSAGE_TYPE = Object.freeze({
 
 export type MessageType = keyof typeof MESSAGE_TYPE;
 
-export const ORIGIN_HOST = {
+export const ORIGIN_HOST: Record<string, string> = {
   FACEBOOK: 'facebook.com',
   WHATSAPP: 'whatsapp.com',
   MESSENGER: 'messenger.com',

--- a/src/js/config.ts
+++ b/src/js/config.ts
@@ -103,7 +103,7 @@ export const MESSAGE_TYPE = Object.freeze({
 
 export type MessageType = keyof typeof MESSAGE_TYPE;
 
-export const ORIGIN_HOST: Record<string, string> = {
+export const ORIGIN_HOST: Record<Origin, string> = {
   FACEBOOK: 'facebook.com',
   WHATSAPP: 'whatsapp.com',
   MESSENGER: 'messenger.com',

--- a/src/js/content/checkCSPForEvals.ts
+++ b/src/js/content/checkCSPForEvals.ts
@@ -47,8 +47,10 @@ function scanForCSPEvalReportViolations(): void {
 function getIsValidDefaultSrc(cspHeaders: Array<string>): boolean {
   return cspHeaders.some(cspHeader => {
     const cspMap = parseCSPString(cspHeader);
-    if (!cspMap.has('script-src') && cspMap.has('default-src')) {
-      if (!cspMap.get('default-src').has("'unsafe-eval'")) {
+    const defaultSrc = cspMap.get('default-src');
+    const scriptSrc = cspMap.get('script-src');
+    if (!scriptSrc && defaultSrc) {
+      if (!defaultSrc.has("'unsafe-eval'")) {
         return true;
       }
     }
@@ -62,9 +64,10 @@ function getIsValidScriptSrcAndHasScriptSrcDirective(
   let hasScriptSrcDirective = false;
   const isValidScriptSrc = cspHeaders.some(cspHeader => {
     const cspMap = parseCSPString(cspHeader);
-    if (cspMap.has('script-src')) {
+    const scriptSrc = cspMap.get('script-src');
+    if (scriptSrc) {
       hasScriptSrcDirective = true;
-      if (!cspMap.get('script-src').has("'unsafe-eval'")) {
+      if (!scriptSrc.has("'unsafe-eval'")) {
         return true;
       }
     }

--- a/src/js/content/checkCSPForEvals.ts
+++ b/src/js/content/checkCSPForEvals.ts
@@ -5,10 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {STATES} from '../config';
 import alertBackgroundOfImminentFetch from './alertBackgroundOfImminentFetch';
 import {parseCSPString} from './parseCSPString';
-import {updateCurrentState} from './updateCurrentState';
+import {invalidateAndThrow} from './updateCurrentState';
 
 function scanForCSPEvalReportViolations(): void {
   document.addEventListener('securitypolicyviolation', e => {
@@ -38,7 +37,7 @@ function scanForCSPEvalReportViolations(): void {
           ) {
             return;
           }
-          updateCurrentState(STATES.INVALID, `Caught eval in ${e.sourceFile}`);
+          invalidateAndThrow(`Caught eval in ${e.sourceFile}`);
         });
     });
   });
@@ -78,27 +77,41 @@ function getIsValidScriptSrcAndHasScriptSrcDirective(
 
 export function checkCSPForEvals(
   cspHeaders: Array<string>,
-  cspReportHeaders: Array<string>,
+  cspReportHeaders: Array<string> | undefined,
 ): boolean {
-  // If CSP is enforcing on evals we don't need to do extra checks
-
-  // Check `script-src` across all headers first since it takes precedence
-  // across multiple headers
   const [hasValidScriptSrcEnforcement, hasScriptSrcDirectiveForEnforce] =
     getIsValidScriptSrcAndHasScriptSrcDirective(cspHeaders);
+
+  // 1. This means that at least one CSP-header declaration has a script-src
+  // directive that has no `unsafe-eval` keyword. This means the browser will
+  // enforce unsafe eval for us.
   if (hasValidScriptSrcEnforcement) {
     return true;
   }
 
+  // 2. If we have no script-src directives, the browser will fall back to
+  // default-src. If at least one declaration has a default-src directive
+  // with no `unsafe-eval`, the browser will enforce for us.
   if (!hasScriptSrcDirectiveForEnforce) {
     if (getIsValidDefaultSrc(cspHeaders)) {
       return true;
     }
   }
 
-  if (cspReportHeaders.length === 0) {
-    updateCurrentState(STATES.INVALID, 'Missing CSP report-only header');
-    return false;
+  // If we've gotten this far, it either means something is invalid, or this is
+  // an older browser. We want to execute WASM, but still prevent unsafe-eval.
+  // Newer browsers support the wasm-unsafe-eval keyword for this purpose, but
+  // for older browsers we need to hack around this.
+
+  // The technique we're using here involves setting report-only headers that
+  // match the rules we checked above, but for enforce headers. These will not
+  // cause the page to break, but will emit events that we can listen for in
+  // scanForCSPEvalReportViolations.
+
+  // 3. Thus, if we've gotten this far and we have no report headers, the page
+  // should be considered invalid.
+  if (!cspReportHeaders || cspReportHeaders.length === 0) {
+    invalidateAndThrow('Missing CSP report-only header');
   }
 
   // Check if at least one header has the correct report setup
@@ -111,14 +124,16 @@ export function checkCSPForEvals(
     hasValidDefaultSrcReport = getIsValidDefaultSrc(cspReportHeaders);
   }
 
+  // 4. If neither
+  //  a. We have at least one script-src without unsafe eval.
+  //  b. We have no script-src, and at least one default-src without unsafe-eval
+  // Then we must invalidate because there is nothing preventing unsafe-eval.
   if (!hasValidScriptSrcReport && !hasValidDefaultSrcReport) {
-    updateCurrentState(
-      STATES.INVALID,
-      'Missing unsafe-eval from CSP report-only header',
-    );
-    return false;
+    invalidateAndThrow('Missing unsafe-eval from CSP report-only header');
   }
-  // Check for evals
+
+  // 5. If we've gotten here without throwing, we can start scanning for violations
+  // from our report-only headers.
   scanForCSPEvalReportViolations();
   return true;
 }

--- a/src/js/content/checkDocumentCSPHeaders.ts
+++ b/src/js/content/checkDocumentCSPHeaders.ts
@@ -64,7 +64,7 @@ function checkCSPForWorkerSrc(
 
 export function checkDocumentCSPHeaders(
   cspHeaders: Array<string>,
-  cspReportHeaders: Array<string>,
+  cspReportHeaders: Array<string> | undefined,
   origin: Origin,
 ): boolean {
   return (

--- a/src/js/content/checkDocumentCSPHeaders.ts
+++ b/src/js/content/checkDocumentCSPHeaders.ts
@@ -34,6 +34,7 @@ function checkCSPForWorkerSrc(
     const cspMap = parseCSPString(cspHeader);
     const workersSrcValues = cspMap.get('worker-src');
     return (
+      workersSrcValues &&
       !workersSrcValues.has('data:') &&
       !workersSrcValues.has('blob:') &&
       /**
@@ -77,5 +78,5 @@ export function getAllowedWorkerCSPs(
 ): Array<Set<string>> {
   return cspHeaders
     .map(header => parseCSPString(header).get('worker-src'))
-    .filter(Boolean);
+    .filter((header): header is Set<string> => !!header);
 }

--- a/src/js/content/checkDocumentCSPHeaders.ts
+++ b/src/js/content/checkDocumentCSPHeaders.ts
@@ -5,14 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {ORIGIN_HOST, STATES} from '../config';
+import {Origin, ORIGIN_HOST, STATES} from '../config';
 import {updateCurrentState} from './updateCurrentState';
 import {parseCSPString} from './parseCSPString';
 import {checkCSPForEvals} from './checkCSPForEvals';
 
 function checkCSPForWorkerSrc(
   cspHeaders: Array<string>,
-  origin: string,
+  origin: Origin,
 ): boolean {
   const host = ORIGIN_HOST[origin];
 
@@ -65,7 +65,7 @@ function checkCSPForWorkerSrc(
 export function checkDocumentCSPHeaders(
   cspHeaders: Array<string>,
   cspReportHeaders: Array<string>,
-  origin: string,
+  origin: Origin,
 ): boolean {
   return (
     checkCSPForEvals(cspHeaders, cspReportHeaders) &&

--- a/src/js/content/checkElementForViolatingAttributes.ts
+++ b/src/js/content/checkElementForViolatingAttributes.ts
@@ -37,10 +37,7 @@ export function checkElementForViolatingAttributes(element: Element): void {
       if (
         (elementAttribute.localName === 'href' ||
           elementAttribute.localName === 'xlink:href') &&
-        element
-          .getAttribute(elementAttribute.localName)
-          .toLowerCase()
-          .startsWith('javascript')
+        elementAttribute.value.toLowerCase().startsWith('javascript')
       ) {
         updateCurrentState(
           STATES.INVALID,

--- a/src/js/content/checkElementForViolatingJSUri.ts
+++ b/src/js/content/checkElementForViolatingJSUri.ts
@@ -19,7 +19,7 @@ function getAttributeValue(
     nodeName.toLowerCase() === elementName &&
     element.hasAttribute(attributeName)
   ) {
-    return element.getAttribute(attributeName).toLowerCase();
+    return element.getAttribute(attributeName)!.toLowerCase();
   }
   return currentAttributeValue;
 }

--- a/src/js/content/checkWorkerEndpointCSP.ts
+++ b/src/js/content/checkWorkerEndpointCSP.ts
@@ -18,13 +18,13 @@ export function checkWorkerEndpointCSP(
   origin: string,
 ): boolean {
   const host = ORIGIN_HOST[origin];
-  const cspHeaders = getCSPHeadersFromWebRequestResponse(response).map(
-    h => h.value,
-  );
-  const cspReportHeaders = getCSPHeadersFromWebRequestResponse(
-    response,
-    true,
-  ).map(h => h.value);
+  const cspHeaders = getCSPHeadersFromWebRequestResponse(response)
+    .map(h => h.value)
+    .filter((header): header is string => !!header);
+
+  const cspReportHeaders = getCSPHeadersFromWebRequestResponse(response, true)
+    .map(h => h.value)
+    .filter((header): header is string => !!header);
 
   const hasValidEvalCSPs = checkCSPForEvals(cspHeaders, cspReportHeaders);
 
@@ -104,8 +104,9 @@ function cspValuesExcludeBlobAndData(cspValues: Set<string>): boolean {
 function getIsValidDefaultSrc(cspHeaders: Array<string>): boolean {
   return cspHeaders.some(cspHeader => {
     const cspMap = parseCSPString(cspHeader);
-    if (!cspMap.has('script-src') && cspMap.has('default-src')) {
-      if (cspValuesExcludeBlobAndData(cspMap.get('default-src'))) {
+    const defaultSrc = cspMap.get('default-src');
+    if (!cspMap.has('script-src') && defaultSrc) {
+      if (cspValuesExcludeBlobAndData(defaultSrc)) {
         return true;
       }
     }
@@ -119,9 +120,10 @@ function getIsValidScriptSrcAndHasScriptSrcDirective(
   let hasScriptSrcDirective = false;
   const isValidScriptSrc = cspHeaders.some(cspHeader => {
     const cspMap = parseCSPString(cspHeader);
-    if (cspMap.has('script-src')) {
+    const scriptSrc = cspMap.get('script-src');
+    if (scriptSrc) {
       hasScriptSrcDirective = true;
-      if (cspValuesExcludeBlobAndData(cspMap.get('script-src'))) {
+      if (cspValuesExcludeBlobAndData(scriptSrc)) {
         return true;
       }
     }

--- a/src/js/content/checkWorkerEndpointCSP.ts
+++ b/src/js/content/checkWorkerEndpointCSP.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {ORIGIN_HOST, STATES} from '../config';
+import {Origin, ORIGIN_HOST, STATES} from '../config';
 import {getCSPHeadersFromWebRequestResponse} from '../shared/getCSPHeadersFromWebRequestResponse';
 import {checkCSPForEvals} from './checkCSPForEvals';
 import {doesWorkerUrlConformToCSP} from './doesWorkerUrlConformToCSP';
@@ -15,7 +15,7 @@ import {updateCurrentState} from './updateCurrentState';
 export function checkWorkerEndpointCSP(
   response: chrome.webRequest.WebResponseCacheDetails,
   documentWorkerCSPs: Array<Set<string>>,
-  origin: string,
+  origin: Origin,
 ): boolean {
   const host = ORIGIN_HOST[origin];
   const cspHeaders = getCSPHeadersFromWebRequestResponse(response)

--- a/src/js/content/genSourceText.ts
+++ b/src/js/content/genSourceText.ts
@@ -35,7 +35,9 @@ export default async function genSourceText(
   if (
     sourceTextParts[sourceTextParts.length - 1].startsWith('//# sourceURL=')
   ) {
-    const sourceURL = sourceTextParts.pop().split('//# sourceURL=')[1] ?? '';
+    // Assume we always have a final part.
+    const finalpart = sourceTextParts.pop()!;
+    const sourceURL = finalpart.split('//# sourceURL=')[1] ?? '';
     if (!sourceURL.startsWith('http')) {
       throw new Error(`Invalid sourceUrl in inlined data script: ${sourceURL}`);
     }

--- a/src/js/content/parseFailedJSON.ts
+++ b/src/js/content/parseFailedJSON.ts
@@ -15,7 +15,7 @@ export default function parseFailedJson(queuedJsonToParse: {
   retry: number;
 }): void {
   try {
-    JSON.parse(queuedJsonToParse.node.textContent);
+    JSON.parse(queuedJsonToParse.node.textContent!);
   } catch (parseError) {
     if (queuedJsonToParse.retry > 0) {
       queuedJsonToParse.retry--;

--- a/src/js/content/updateCurrentState.ts
+++ b/src/js/content/updateCurrentState.ts
@@ -5,16 +5,35 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {MESSAGE_TYPE, Origin, State} from '../config';
+import {MESSAGE_TYPE, Origin, State, STATES} from '../config';
 import {sendMessageToBackground} from '../shared/sendMessageToBackground';
 
-export const currentOrigin: {val: Origin} = {val: null};
+let currentOrigin: Origin | undefined;
+
+export function setCurrentOrigin(origin: Origin): void {
+  currentOrigin = origin;
+}
+
+export function getCurrentOrigin(): Origin {
+  if (!currentOrigin) {
+    invalidateAndThrow(
+      'Attemting to access currentOrigin before it has been set',
+    );
+  }
+
+  return currentOrigin;
+}
 
 export function updateCurrentState(state: State, details?: string) {
   sendMessageToBackground({
     type: MESSAGE_TYPE.UPDATE_STATE,
     state,
-    origin: currentOrigin.val as Origin,
+    origin: getCurrentOrigin(),
     details,
   });
+}
+
+export function invalidateAndThrow(details?: string): never {
+  updateCurrentState(STATES.INVALID, details);
+  throw new Error(details);
 }

--- a/src/js/contentUtils.ts
+++ b/src/js/contentUtils.ts
@@ -274,12 +274,9 @@ export function storeFoundJS(scriptNodeMaybe: HTMLScriptElement): void {
     if (originConfig.scriptsShouldHaveManifestProp) {
       const dataBtManifest = scriptNodeMaybe.getAttribute('data-btmanifest');
       if (dataBtManifest == null) {
-        // All src specified scripts should have a manifest atribution
-        updateCurrentState(
-          STATES.INVALID,
+        invalidateAndThrow(
           `No data-btmanifest attribute found on script ${scriptNodeMaybe.src}`,
         );
-        invalidateAndThrow('Script is missing `data-btmanifest` prop');
       }
       version = dataBtManifest.split('_')[0];
       const otherType = dataBtManifest.split('_')[1];

--- a/src/js/contentUtils.ts
+++ b/src/js/contentUtils.ts
@@ -133,15 +133,14 @@ export function storeFoundJS(scriptNodeMaybe: HTMLScriptElement): void {
     let rawManifest: RawManifest | null = null;
     try {
       rawManifest = JSON.parse(scriptNodeMaybe.textContent!);
+      if (!rawManifest) {
+        throw new Error('rawManifest is null or empty');
+      }
     } catch (manifestParseError) {
       setTimeout(
         () => parseFailedJSON({node: scriptNodeMaybe, retry: 5000}),
         20,
       );
-      return;
-    }
-
-    if (rawManifest === null) {
       return;
     }
 

--- a/src/js/contentUtils.ts
+++ b/src/js/contentUtils.ts
@@ -554,11 +554,6 @@ export function startFor(origin: Origin, config: ContentScriptConfig): void {
             'Expected CSP Headers in CONTENT_SCRIPT_START response',
           );
         }
-        if (!resp.cspReportHeaders) {
-          invalidateAndThrow(
-            'Expected CSP Report Headers in CONTENT_SCRIPT_START response',
-          );
-        }
         const validCSP = checkDocumentCSPHeaders(
           resp.cspHeaders,
           resp.cspReportHeaders,

--- a/src/js/contentUtils.ts
+++ b/src/js/contentUtils.ts
@@ -20,7 +20,12 @@ import {
 } from './content/checkDocumentCSPHeaders';
 import downloadJSArchive from './content/downloadJSArchive';
 import alertBackgroundOfImminentFetch from './content/alertBackgroundOfImminentFetch';
-import {currentOrigin, updateCurrentState} from './content/updateCurrentState';
+import {
+  getCurrentOrigin,
+  setCurrentOrigin,
+  updateCurrentState,
+  invalidateAndThrow,
+} from './content/updateCurrentState';
 import checkElementForViolatingJSUri from './content/checkElementForViolatingJSUri';
 import {checkElementForViolatingAttributes} from './content/checkElementForViolatingAttributes';
 import {sendMessageToBackground} from './shared/sendMessageToBackground';
@@ -29,6 +34,7 @@ import genSourceText from './content/genSourceText';
 import isPathnameExcluded from './content/isPathNameExcluded';
 import {doesWorkerUrlConformToCSP} from './content/doesWorkerUrlConformToCSP';
 import {checkWorkerEndpointCSP} from './content/checkWorkerEndpointCSP';
+import {MessagePayload} from './shared/MessageTypes';
 
 type ContentScriptConfig = {
   checkLoggedInFromCookie: boolean;
@@ -57,7 +63,12 @@ const SOURCE_SCRIPTS = new Map();
 const INLINE_SCRIPTS: Array<Map<string, string>> = [];
 
 // Map<version, Array<ScriptDetails>>
-export const FOUND_SCRIPTS = new Map<string, Array<ScriptDetails>>([['', []]]);
+export const UNINITIALIZED = 'UNINITIALIZED';
+const BOTH = 'BOTH';
+let currentFilterType = UNINITIALIZED;
+export const FOUND_SCRIPTS = new Map<string, Array<ScriptDetails>>([
+  [UNINITIALIZED, []],
+]);
 const ALL_FOUND_SCRIPT_TAGS = new Set();
 
 type ScriptDetailsWithSrc = {
@@ -71,8 +82,6 @@ type ScriptDetailsRaw = {
   otherType: string;
 };
 type ScriptDetails = ScriptDetailsRaw | ScriptDetailsWithSrc;
-
-let currentFilterType = '';
 let manifestTimeoutID: string | number = '';
 
 export type RawManifestOtherHashes = {
@@ -93,7 +102,9 @@ function isTopWindow(): boolean {
 }
 function isSameDomainAsTopWindow(): boolean {
   try {
-    return window.location.origin === window.top.location.origin;
+    // This is inside a try/catch because even attempting to access the `origin`
+    // property will throw a SecurityError if the domains don't match.
+    return window.location.origin === window.top!.location.origin;
   } catch {
     return false;
   }
@@ -121,7 +132,7 @@ export function storeFoundJS(scriptNodeMaybe: HTMLScriptElement): void {
 
     let rawManifest: RawManifest | null = null;
     try {
-      rawManifest = JSON.parse(scriptNodeMaybe.textContent);
+      rawManifest = JSON.parse(scriptNodeMaybe.textContent!);
     } catch (manifestParseError) {
       setTimeout(
         () => parseFailedJSON({node: scriptNodeMaybe, retry: 5000}),
@@ -130,79 +141,114 @@ export function storeFoundJS(scriptNodeMaybe: HTMLScriptElement): void {
       return;
     }
 
+    if (rawManifest === null) {
+      return;
+    }
+
     let leaves = rawManifest.leaves;
-    let otherHashes: RawManifestOtherHashes = null;
     let otherType = '';
     let roothash = rawManifest.root;
     let version = rawManifest.version;
+    let messagePayload: MessagePayload;
     if (originConfig.longTailIsLoadedConditionally) {
       leaves = rawManifest.manifest;
-      otherHashes = rawManifest.manifest_hashes;
-      otherType = scriptNodeMaybe.getAttribute('data-manifest-type');
+      const otherHashes = rawManifest.manifest_hashes;
       roothash = otherHashes.combined_hash;
-      version = scriptNodeMaybe.getAttribute('data-manifest-rev');
+
+      const maybeManifestType =
+        scriptNodeMaybe.getAttribute('data-manifest-type');
+      if (maybeManifestType === null) {
+        updateCurrentState(
+          STATES.INVALID,
+          'manifest is missing `data-manifest-type` prop',
+        );
+      } else {
+        otherType = maybeManifestType;
+      }
+
+      const maybeManifestRev =
+        scriptNodeMaybe.getAttribute('data-manifest-rev');
+      if (maybeManifestRev === null) {
+        updateCurrentState(
+          STATES.INVALID,
+          'manifest is missing `data-manifest-rev` prop',
+        );
+      } else {
+        version = maybeManifestRev;
+      }
 
       // If this is the first manifest we've found, start processing scripts for
       // that type. If we have encountered a second manifest, we can assume both
       // main and longtail manifests are present.
-      if (currentFilterType === '') {
+      if (currentFilterType === UNINITIALIZED) {
         currentFilterType = otherType;
       } else {
-        currentFilterType = 'BOTH';
+        currentFilterType = BOTH;
       }
+
+      messagePayload = {
+        type: MESSAGE_TYPE.LOAD_COMPANY_MANIFEST,
+        leaves,
+        origin: getCurrentOrigin(),
+        otherHashes: otherHashes,
+        rootHash: roothash,
+        workaround: scriptNodeMaybe.innerHTML,
+        version,
+      };
     } else {
       // for whatsapp
-      currentFilterType = 'BOTH';
+      currentFilterType = BOTH;
+
+      messagePayload = {
+        type: MESSAGE_TYPE.LOAD_MANIFEST,
+        leaves,
+        origin: getCurrentOrigin(),
+        rootHash: roothash,
+        workaround: scriptNodeMaybe.innerHTML,
+        version,
+      };
     }
+
     // now that we know the actual version of the scripts, transfer the ones we know about.
     // also set the correct manifest type, "otherType" for already collected scripts
-    if (FOUND_SCRIPTS.has('')) {
+    const foundScriptsWithoutVersion = FOUND_SCRIPTS.get(UNINITIALIZED);
+    if (foundScriptsWithoutVersion) {
+      const scriptsWithUpdatedType = foundScriptsWithoutVersion.map(script => ({
+        ...script,
+        otherType: currentFilterType,
+      }));
+
       FOUND_SCRIPTS.set(version, [
-        ...FOUND_SCRIPTS.get('').map(s => ({
-          ...s,
-          otherType: currentFilterType,
-        })),
+        ...scriptsWithUpdatedType,
         ...(FOUND_SCRIPTS.get(version) ?? []),
       ]);
-      FOUND_SCRIPTS.delete('');
+      FOUND_SCRIPTS.delete(UNINITIALIZED);
     } else if (!FOUND_SCRIPTS.has(version)) {
       // New version is being loaded in
       FOUND_SCRIPTS.set(version, []);
     }
 
-    sendMessageToBackground(
-      {
-        type: MESSAGE_TYPE.LOAD_MANIFEST,
-        useCompanyManifest: originConfig.useCompanyManifest,
-        leaves: leaves,
-        origin: currentOrigin.val,
-        otherHashes: otherHashes,
-        rootHash: roothash,
-        workaround: scriptNodeMaybe.innerHTML,
-        version,
-      },
-      response => {
-        // then start processing of it's JS
-        if (response.valid) {
-          if (manifestTimeoutID !== '') {
-            clearTimeout(manifestTimeoutID);
-            manifestTimeoutID = '';
-          }
-          window.setTimeout(() => processFoundJS(version), 0);
-        } else {
-          if ('UNKNOWN_ENDPOINT_ISSUE' === response.reason) {
-            updateCurrentState(STATES.TIMEOUT);
-            return;
-          }
-          updateCurrentState(STATES.INVALID);
+    sendMessageToBackground(messagePayload, response => {
+      // then start processing of it's JS
+      if (response.valid) {
+        if (manifestTimeoutID !== '') {
+          clearTimeout(manifestTimeoutID);
+          manifestTimeoutID = '';
         }
-      },
-    );
+        window.setTimeout(() => processFoundJS(version), 0);
+      } else {
+        if ('UNKNOWN_ENDPOINT_ISSUE' === response.reason) {
+          updateCurrentState(STATES.TIMEOUT);
+          return;
+        }
+        updateCurrentState(STATES.INVALID);
+      }
+    });
   }
 
   if (scriptNodeMaybe.getAttribute('type') === 'application/json') {
     try {
-      JSON.parse(scriptNodeMaybe.textContent);
+      JSON.parse(scriptNodeMaybe.textContent!);
     } catch (parseError) {
       setTimeout(
         () => parseFailedJSON({node: scriptNodeMaybe, retry: 1500}),
@@ -222,8 +268,8 @@ export function storeFoundJS(scriptNodeMaybe: HTMLScriptElement): void {
   }
 
   // Need to get the src of the JS
-  let scriptDetails = null;
-  let version = '';
+  let scriptDetails: ScriptDetails;
+  let version = UNINITIALIZED;
 
   if (scriptNodeMaybe.src !== '' || scriptNodeMaybe.innerHTML !== '') {
     if (originConfig.scriptsShouldHaveManifestProp) {
@@ -234,8 +280,8 @@ export function storeFoundJS(scriptNodeMaybe: HTMLScriptElement): void {
           STATES.INVALID,
           `No data-btmanifest attribute found on script ${scriptNodeMaybe.src}`,
         );
+        invalidateAndThrow('Script is missing `data-btmanifest` prop');
       }
-
       version = dataBtManifest.split('_')[0];
       const otherType = dataBtManifest.split('_')[1];
       scriptDetails = {
@@ -253,6 +299,7 @@ export function storeFoundJS(scriptNodeMaybe: HTMLScriptElement): void {
       } else {
         // no src, access innerHTML for the code
         const hashLookupAttribute =
+          // @ts-ignore: This is just sort of hole in the DOM definitions.
           scriptNodeMaybe.attributes['data-binary-transparency-hash-key'];
         const hashLookupKey = hashLookupAttribute && hashLookupAttribute.value;
         scriptDetails = {
@@ -264,17 +311,19 @@ export function storeFoundJS(scriptNodeMaybe: HTMLScriptElement): void {
       }
     }
 
-    if (FOUND_SCRIPTS.has(version)) {
-      FOUND_SCRIPTS.get(version).push(scriptDetails);
+    const scriptsForVersion = FOUND_SCRIPTS.get(version);
+    if (scriptsForVersion) {
+      scriptsForVersion.push(scriptDetails);
     } else {
-      if (version != '') {
+      if (version != UNINITIALIZED) {
         FOUND_SCRIPTS.set(version, [scriptDetails]);
       } else {
-        FOUND_SCRIPTS.get(FOUND_SCRIPTS.keys().next().value).push(
+        FOUND_SCRIPTS.get(FOUND_SCRIPTS.keys().next().value)?.push(
           scriptDetails,
         );
       }
     }
+
     updateCurrentState(STATES.PROCESSING);
   }
 }
@@ -362,11 +411,13 @@ async function processJSWithSrc(
     if (DOWNLOAD_JS_ENABLED) {
       const fileNameArr = script.src.split('/');
       const fileName = fileNameArr[fileNameArr.length - 1].split('?')[0];
+      const responseBody = sourceResponse.clone().body;
+      if (!responseBody) {
+        throw new Error('Response for fetched script has no body');
+      }
       SOURCE_SCRIPTS.set(
         fileName,
-        sourceResponse
-          .clone()
-          .body.pipeThrough(new window.CompressionStream('gzip')),
+        responseBody.pipeThrough(new window.CompressionStream('gzip')),
       );
     }
     const sourceText = await genSourceText(sourceResponse);
@@ -378,7 +429,7 @@ async function processJSWithSrc(
           {
             type: MESSAGE_TYPE.RAW_JS,
             rawjs: jsPackage.trimStart(),
-            origin: currentOrigin.val,
+            origin: getCurrentOrigin(),
             version: version,
           },
           response => {
@@ -402,15 +453,20 @@ async function processJSWithSrc(
 }
 
 export const processFoundJS = async (version: string): Promise<void> => {
-  const fullscripts = FOUND_SCRIPTS.get(version).splice(0);
-  const scripts = fullscripts.filter(script => {
+  const scriptsForVersion = FOUND_SCRIPTS.get(version);
+  if (!scriptsForVersion) {
+    invalidateAndThrow(
+      `attempting to process scripts for nonexistent version ${version}`,
+    );
+  }
+  const scripts = scriptsForVersion.splice(0).filter(script => {
     if (
       script.otherType === currentFilterType ||
-      ['BOTH', ''].includes(currentFilterType)
+      [BOTH, UNINITIALIZED].includes(currentFilterType)
     ) {
       return true;
     } else {
-      FOUND_SCRIPTS.get(version).push(script);
+      scriptsForVersion.push(script);
     }
   });
   let pendingScriptCount = scripts.length;
@@ -447,14 +503,14 @@ export const processFoundJS = async (version: string): Promise<void> => {
         {
           type: script.type,
           rawjs: script.rawjs.trimStart(),
-          origin: currentOrigin.val,
+          origin: getCurrentOrigin(),
           version: version,
         },
         response => {
           pendingScriptCount--;
           const inlineScriptMap = new Map();
           if (response.valid) {
-            inlineScriptMap.set(response.hash, script.rawjs);
+            inlineScriptMap.set(response.hash!, script.rawjs);
             INLINE_SCRIPTS.push(inlineScriptMap);
             if (pendingScriptCount == 0) {
               updateCurrentState(STATES.VALID);
@@ -462,7 +518,7 @@ export const processFoundJS = async (version: string): Promise<void> => {
           } else {
             inlineScriptMap.set('hash not in manifest', script.rawjs);
             INLINE_SCRIPTS.push(inlineScriptMap);
-            if (KNOWN_EXTENSION_HASHES.includes(response.hash)) {
+            if (KNOWN_EXTENSION_HASHES.includes(response.hash!)) {
               updateCurrentState(STATES.RISK);
             } else {
               updateCurrentState(STATES.INVALID, 'Invalid ScriptDetailsRaw');
@@ -472,7 +528,7 @@ export const processFoundJS = async (version: string): Promise<void> => {
             type: MESSAGE_TYPE.DEBUG,
             log:
               'processed the RAW_JS, response is ' +
-              response.hash +
+              response.hash! +
               ' ' +
               JSON.stringify(response).substring(0, 500),
           });
@@ -488,17 +544,29 @@ let allowedWorkerCSPs: Array<Set<string>> = [];
 
 export function startFor(origin: Origin, config: ContentScriptConfig): void {
   originConfig = config;
+  setCurrentOrigin(origin);
   sendMessageToBackground(
     {
       type: MESSAGE_TYPE.CONTENT_SCRIPT_START,
+      checkCSPHeaders: originConfig.enforceCSPHeaders,
       origin,
     },
     resp => {
       if (originConfig.enforceCSPHeaders) {
+        if (!resp.cspHeaders) {
+          invalidateAndThrow(
+            'Expected CSP Headers in CONTENT_SCRIPT_START response',
+          );
+        }
+        if (!resp.cspReportHeaders) {
+          invalidateAndThrow(
+            'Expected CSP Report Headers in CONTENT_SCRIPT_START response',
+          );
+        }
         const validCSP = checkDocumentCSPHeaders(
           resp.cspHeaders,
           resp.cspReportHeaders,
-          currentOrigin.val,
+          getCurrentOrigin(),
         );
         if (validCSP) {
           allowedWorkerCSPs = getAllowedWorkerCSPs(resp.cspHeaders);
@@ -527,7 +595,6 @@ export function startFor(origin: Origin, config: ContentScriptConfig): void {
   }
   if (isUserLoggedIn) {
     updateCurrentState(STATES.PROCESSING);
-    currentOrigin.val = origin;
     scanForScripts();
     // set the timeout once, in case there's an iframe and contentUtils sets another manifest timer
     if (manifestTimeoutID === '') {
@@ -569,7 +636,7 @@ chrome.runtime.onMessage.addListener(request => {
             checkWorkerEndpointCSP(
               request.response,
               allowedWorkerCSPs,
-              currentOrigin.val,
+              getCurrentOrigin(),
             );
           }
         }
@@ -579,10 +646,15 @@ chrome.runtime.onMessage.addListener(request => {
         log: `Tab is processing ${request.response.url}`,
       });
       ALL_FOUND_SCRIPT_TAGS.add(request.response.url);
-      FOUND_SCRIPTS.get(FOUND_SCRIPTS.keys().next().value).push({
-        src: request.response.url,
-        otherType: currentFilterType,
-      });
+      const uninitializedScripts = FOUND_SCRIPTS.get(
+        FOUND_SCRIPTS.keys().next().value,
+      );
+      if (uninitializedScripts) {
+        uninitializedScripts.push({
+          src: request.response.url,
+          otherType: currentFilterType,
+        });
+      }
       updateCurrentState(STATES.PROCESSING);
     }
   } else if (request.greeting === 'sniffableMimeTypeResource') {

--- a/src/js/popup.ts
+++ b/src/js/popup.ts
@@ -187,15 +187,14 @@ function attachListeners(origin: string | null): void {
 function updateDisplay(state: string | null): void {
   const popupState = STATE_TO_POPUP_STATE[state!] || state;
   Array.from(document.getElementsByClassName('state_boundary')).forEach(
-    // @ts-ignore: getElementsByClassName returns HTMLCollectionOf<Element>
-    // where HTMLElement extends Element. Unclear when this would return
-    // non-HTMLElement.
-    (element: HTMLElement) => {
-      if (element.id == popupState) {
-        element.style.display = 'flex';
-        document.body.className = popupState + '_body';
-      } else {
-        element.style.display = 'none';
+    (element: Element) => {
+      if (element instanceof HTMLElement) {
+        if (element.id == popupState) {
+          element.style.display = 'flex';
+          document.body.className = popupState + '_body';
+        } else {
+          element.style.display = 'none';
+        }
       }
     },
   );

--- a/src/js/popup.ts
+++ b/src/js/popup.ts
@@ -12,7 +12,7 @@ import {
   STATES,
 } from './config.js';
 
-const STATE_TO_POPUP_STATE = {
+const STATE_TO_POPUP_STATE: Record<string, string> = {
   [STATES.START]: 'loading',
   [STATES.PROCESSING]: 'loading',
   [STATES.IGNORE]: 'loading',
@@ -22,7 +22,14 @@ const STATE_TO_POPUP_STATE = {
   [STATES.TIMEOUT]: 'warning_timeout',
 };
 
-const ORIGIN_TO_LEARN_MORE_PAGES = {
+type TranslatedMessages = {
+  about: string;
+  failure: string;
+  risk: string;
+  timeout: string;
+};
+
+const ORIGIN_TO_LEARN_MORE_PAGES: Record<string, TranslatedMessages> = {
   [ORIGIN_TYPE.FACEBOOK]: {
     about: chrome.i18n.getMessage('about_code_verify_faq_url_fb'),
     failure: chrome.i18n.getMessage('validation_failure_faq_url_fb'),
@@ -58,7 +65,7 @@ function attachTextToHtml(): void {
 }
 
 function attachListeners(origin: string | null): void {
-  if (!(origin in ORIGIN_TO_LEARN_MORE_PAGES)) {
+  if (!(origin && origin in ORIGIN_TO_LEARN_MORE_PAGES)) {
     throw new Error(
       `Learn more pages for origin type: ${origin} do not exist!`,
     );
@@ -71,7 +78,7 @@ function attachListeners(origin: string | null): void {
   });
 
   const closeMenuButton = document.getElementById('close_menu');
-  closeMenuButton.addEventListener('click', () => window.close());
+  closeMenuButton!.addEventListener('click', () => window.close());
 
   const menuRowList = document.getElementsByClassName('menu_row');
 
@@ -96,7 +103,7 @@ function attachListeners(origin: string | null): void {
     downloadTextList[0].addEventListener('click', () => {
       chrome.tabs.query({active: true, currentWindow: true}, function (tabs) {
         chrome.tabs.sendMessage(
-          tabs[0].id,
+          tabs[0].id!,
           {greeting: 'downloadSource'},
           () => {},
         );
@@ -106,17 +113,17 @@ function attachListeners(origin: string | null): void {
       downloadTextList[0].style.cursor = 'pointer';
     }
 
-    downloadSrcButton.onclick = () => {
+    downloadSrcButton!.onclick = () => {
       chrome.tabs.query({active: true, currentWindow: true}, function (tabs) {
         chrome.tabs.sendMessage(
-          tabs[0].id,
+          tabs[0].id!,
           {greeting: 'downloadSource'},
           () => {},
         );
       });
     };
 
-    downloadSrcButton.style.cursor = 'pointer';
+    downloadSrcButton!.style.cursor = 'pointer';
 
     downloadTextList[0].addEventListener('click', () =>
       updateDisplay('download'),
@@ -133,7 +140,7 @@ function attachListeners(origin: string | null): void {
     if (downloadMessagePartTwo != null) {
       downloadMessagePartTwo.remove();
     }
-    downloadSrcButton.remove();
+    downloadSrcButton!.remove();
   }
 
   const learnMoreList = document.getElementsByClassName(
@@ -178,8 +185,11 @@ function attachListeners(origin: string | null): void {
 }
 
 function updateDisplay(state: string | null): void {
-  const popupState = STATE_TO_POPUP_STATE[state] || state;
+  const popupState = STATE_TO_POPUP_STATE[state!] || state;
   Array.from(document.getElementsByClassName('state_boundary')).forEach(
+    // @ts-ignore: getElementsByClassName returns HTMLCollectionOf<Element>
+    // where HTMLElement extends Element. Unclear when this would return
+    // non-HTMLElement.
     (element: HTMLElement) => {
       if (element.id == popupState) {
         element.style.display = 'flex';

--- a/src/js/shared/MessageTypes.d.ts
+++ b/src/js/shared/MessageTypes.d.ts
@@ -10,11 +10,18 @@ import {RawManifestOtherHashes} from '../contentUtils';
 
 export type MessagePayload =
   | {
-      type: typeof MESSAGE_TYPE.LOAD_MANIFEST;
-      useCompanyManifest: boolean;
+      type: typeof MESSAGE_TYPE.LOAD_COMPANY_MANIFEST;
       origin: Origin;
       rootHash: string;
       otherHashes: RawManifestOtherHashes;
+      leaves: Array<string>;
+      version: string;
+      workaround: string;
+    }
+  | {
+      type: typeof MESSAGE_TYPE.LOAD_MANIFEST;
+      origin: Origin;
+      rootHash: string;
       leaves: Array<string>;
       version: string;
       workaround: string;
@@ -43,6 +50,7 @@ export type MessagePayload =
     }
   | {
       type: typeof MESSAGE_TYPE.CONTENT_SCRIPT_START;
+      checkCSPHeaders: boolean;
       origin: Origin;
     }
   | {

--- a/src/js/shared/getCSPHeadersFromWebRequestResponse.ts
+++ b/src/js/shared/getCSPHeadersFromWebRequestResponse.ts
@@ -9,7 +9,11 @@ export function getCSPHeadersFromWebRequestResponse(
   response: chrome.webRequest.WebResponseHeadersDetails,
   reportHeader = false,
 ): Array<chrome.webRequest.HttpHeader> {
-  return response.responseHeaders.filter(
+  const responseHeaders = response.responseHeaders;
+  if (!responseHeaders) {
+    throw new Error('Request is missing responseHeaders');
+  }
+  return responseHeaders.filter(
     header =>
       header.name.toLowerCase() ===
       (reportHeader

--- a/src/js/shared/nestedDataHelpers.ts
+++ b/src/js/shared/nestedDataHelpers.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export function setOrUpdateMapInMap<OuterKey, InnerKey, Value>(
+  outerMap: Map<OuterKey, Map<InnerKey, Value>>,
+  outerKey: OuterKey,
+  innerKey: InnerKey,
+  value: Value,
+): Map<OuterKey, Map<InnerKey, Value>> {
+  const innerMap = outerMap.get(outerKey) ?? new Map();
+  innerMap.set(innerKey, value);
+  if (!outerMap.has(outerKey)) {
+    outerMap.set(outerKey, innerMap);
+  }
+  return outerMap;
+}
+
+export function setOrUpdateSetInMap<OuterKey, Value>(
+  outerMap: Map<OuterKey, Set<Value>>,
+  outerKey: OuterKey,
+  value: Value,
+): Map<OuterKey, Set<Value>> {
+  const innerSet = outerMap.get(outerKey) ?? new Set();
+  innerSet.add(value);
+  if (!outerMap.has(outerKey)) {
+    outerMap.set(outerKey, innerSet);
+  }
+  return outerMap;
+}

--- a/src/js/shared/sendMessageToBackground.ts
+++ b/src/js/shared/sendMessageToBackground.ts
@@ -11,5 +11,6 @@ export function sendMessageToBackground(
   message: MessagePayload,
   callback?: (response: MessageResponse) => void,
 ): void {
+  callback ??= () => {};
   chrome.runtime.sendMessage(message, callback);
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,10 @@
 {
   "compilerOptions": {
-    "target": "ES6",
     "esModuleInterop": true,
+    "lib": ["ES2021"],
     "moduleResolution": "node",
-    "lib": ["ES2021"]
+    "noFallthroughCasesInSwitch": true,
+    "strict": true,
+    "target": "ES6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@aashutoshrathi/word-wrap@^1.2.3":
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
+  integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
+
 "@ampproject/remapping@^2.2.0":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.1.tgz#99e8e11851128b8702cd57c33684f1d0f260b630"
@@ -134,11 +139,6 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz#533f36457a25814cf1df6488523ad547d784a99f"
   integrity sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==
 
-"@babel/helper-validator-identifier@^7.14.5":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz#9c97e30d31b2b8c72a1d08984f2ca9b574d7a076"
-  integrity sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==
-
 "@babel/helper-validator-identifier@^7.22.20":
   version "7.22.20"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz#c4ae002c61d2879e724581d96665583dbc1dc0e0"
@@ -158,16 +158,7 @@
     "@babel/traverse" "^7.23.2"
     "@babel/types" "^7.23.0"
 
-"@babel/highlight@^7.10.4":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.14.5.tgz#6861a52f03966405001f6aa534a01a24d99e8cd9"
-  integrity sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.14.5"
-    chalk "^2.0.0"
-    js-tokens "^4.0.0"
-
-"@babel/highlight@^7.22.13":
+"@babel/highlight@^7.10.4", "@babel/highlight@^7.22.13":
   version "7.22.20"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.22.20.tgz#4ca92b71d80554b01427815e06f2df965b9c1f54"
   integrity sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==
@@ -318,17 +309,17 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@eslint-community/eslint-utils@^4.2.0":
+"@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
   integrity sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==
   dependencies:
     eslint-visitor-keys "^3.3.0"
 
-"@eslint-community/regexpp@^4.4.0":
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.5.1.tgz#cdd35dce4fa1a89a4fd42b1599eb35b3af408884"
-  integrity sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==
+"@eslint-community/regexpp@^4.5.1", "@eslint-community/regexpp@^4.6.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.9.1.tgz#449dfa81a57a1d755b09aa58d826c1262e4283b4"
+  integrity sha512-Y27x+MBLjXa+0JWDhykM3+JE+il3kHKAEqabfEWq3SDhZjLYb6/BHL/JKFnH3fe207JaXkyDo685Oc2Glt6ifA==
 
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"
@@ -345,14 +336,14 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@eslint/eslintrc@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-2.0.3.tgz#4910db5505f4d503f27774bf356e3704818a0331"
-  integrity sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==
+"@eslint/eslintrc@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-2.1.2.tgz#c6936b4b328c64496692f76944e755738be62396"
+  integrity sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==
   dependencies:
     ajv "^6.12.4"
     debug "^4.3.2"
-    espree "^9.5.2"
+    espree "^9.6.0"
     globals "^13.19.0"
     ignore "^5.2.0"
     import-fresh "^3.2.1"
@@ -360,17 +351,17 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@eslint/js@8.40.0":
-  version "8.40.0"
-  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.40.0.tgz#3ba73359e11f5a7bd3e407f70b3528abfae69cec"
-  integrity sha512-ElyB54bJIhXQYVKjDSvCkPO1iU1tSAeVQJbllWJq1XQSmmA4dgFk8CbiBGpiOPxleE48vDogxCtmMYku4HSVLA==
+"@eslint/js@8.52.0":
+  version "8.52.0"
+  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.52.0.tgz#78fe5f117840f69dc4a353adf9b9cd926353378c"
+  integrity sha512-mjZVbpaeMZludF2fsWLD0Z9gCref1Tk4i9+wddjRvpUNqqcndPkBD09N/Mapey0b3jaXbLm2kICwFv2E64QinA==
 
-"@humanwhocodes/config-array@^0.11.8":
-  version "0.11.8"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.8.tgz#03595ac2075a4dc0f191cc2131de14fbd7d410b9"
-  integrity sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==
+"@humanwhocodes/config-array@^0.11.13":
+  version "0.11.13"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.13.tgz#075dc9684f40a531d9b26b0822153c1e832ee297"
+  integrity sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==
   dependencies:
-    "@humanwhocodes/object-schema" "^1.2.1"
+    "@humanwhocodes/object-schema" "^2.0.1"
     debug "^4.1.1"
     minimatch "^3.0.5"
 
@@ -389,14 +380,14 @@
   integrity sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==
 
 "@humanwhocodes/object-schema@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz#87de7af9c231826fdd68ac7258f77c429e0e5fcf"
-  integrity sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==
-
-"@humanwhocodes/object-schema@^1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
+
+"@humanwhocodes/object-schema@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz#e5211452df060fa8522b55c7b3c0c4d1981cb044"
+  integrity sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
@@ -460,7 +451,7 @@
     slash "^3.0.0"
     strip-ansi "^6.0.0"
 
-"@jest/environment@^29.6.2", "@jest/environment@^29.7.0":
+"@jest/environment@^29.7.0":
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-29.7.0.tgz#24d61f54ff1f786f3cd4073b4b94416383baf2a7"
   integrity sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==
@@ -469,13 +460,6 @@
     "@jest/types" "^29.6.3"
     "@types/node" "*"
     jest-mock "^29.7.0"
-
-"@jest/expect-utils@^29.4.3":
-  version "29.4.3"
-  resolved "https://registry.yarnpkg.com/@jest/expect-utils/-/expect-utils-29.4.3.tgz#95ce4df62952f071bcd618225ac7c47eaa81431e"
-  integrity sha512-/6JWbkxHOP8EoS8jeeTd9dTfc9Uawi+43oLKHfp6zzux3U2hqOOVnV3ai4RpDYHOccL6g+5nrxpoc8DmJxtXVQ==
-  dependencies:
-    jest-get-type "^29.4.3"
 
 "@jest/expect-utils@^29.7.0":
   version "29.7.0"
@@ -492,7 +476,7 @@
     expect "^29.7.0"
     jest-snapshot "^29.7.0"
 
-"@jest/fake-timers@^29.6.2", "@jest/fake-timers@^29.7.0":
+"@jest/fake-timers@^29.7.0":
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-29.7.0.tgz#fd91bf1fffb16d7d0d24a426ab1a47a49881a565"
   integrity sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==
@@ -543,13 +527,6 @@
     string-length "^4.0.1"
     strip-ansi "^6.0.0"
     v8-to-istanbul "^9.0.1"
-
-"@jest/schemas@^29.4.3":
-  version "29.4.3"
-  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-29.4.3.tgz#39cf1b8469afc40b6f5a2baaa146e332c4151788"
-  integrity sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==
-  dependencies:
-    "@sinclair/typebox" "^0.25.16"
 
 "@jest/schemas@^29.6.3":
   version "29.6.3"
@@ -608,19 +585,7 @@
     slash "^3.0.0"
     write-file-atomic "^4.0.2"
 
-"@jest/types@^29.4.3":
-  version "29.4.3"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-29.4.3.tgz#9069145f4ef09adf10cec1b2901b2d390031431f"
-  integrity sha512-bPYfw8V65v17m2Od1cv44FH+SiKW7w2Xu7trhcdTLUmSv85rfKsP+qXSjO4KGJr4dtPSzl/gvslZBXctf1qGEA==
-  dependencies:
-    "@jest/schemas" "^29.4.3"
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^3.0.0"
-    "@types/node" "*"
-    "@types/yargs" "^17.0.8"
-    chalk "^4.0.0"
-
-"@jest/types@^29.6.1", "@jest/types@^29.6.3":
+"@jest/types@^29.6.3":
   version "29.6.3"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-29.6.3.tgz#1131f8cf634e7e84c5e77bab12f052af585fba59"
   integrity sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==
@@ -685,35 +650,30 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@rollup/plugin-eslint@^9.0.3":
-  version "9.0.3"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-eslint/-/plugin-eslint-9.0.3.tgz#f5e8c22d557bef02570e4f1770fb085568ea4b37"
-  integrity sha512-iV2m9BhPdsjQzmRVe3Nzovrjxbdq5Slva8bvUSzbM4gSBUaGXAFnFXcHcvO4N4tSuirZoY61mkn8KtV3G6o0iQ==
+"@rollup/plugin-eslint@^9.0.5":
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-eslint/-/plugin-eslint-9.0.5.tgz#6153f5b72bad1833f5b5ce88cc03c3fe767a9c66"
+  integrity sha512-C4nh0sSeJuxVW5u5tDX+dCMjKcNfHm4hS+zeUVh1si7gttnhgGbrmPkUxIX7iZgYABwdEh/ewyMbZB+WXjSJdA==
   dependencies:
     "@rollup/pluginutils" "^5.0.1"
     eslint "^8.24.0"
 
-"@rollup/plugin-typescript@^11.0.0":
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-typescript/-/plugin-typescript-11.0.0.tgz#f136272d1df5209daca0cb6f171c574b1d505545"
-  integrity sha512-goPyCWBiimk1iJgSTgsehFD5OOFHiAknrRJjqFCudcW8JtWiBlK284Xnn4flqMqg6YAjVG/EE+3aVzrL5qNSzQ==
+"@rollup/plugin-typescript@^11.1.5":
+  version "11.1.5"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-typescript/-/plugin-typescript-11.1.5.tgz#039c763bf943a5921f3f42be255895e75764cb91"
+  integrity sha512-rnMHrGBB0IUEv69Q8/JGRD/n4/n6b3nfpufUu26axhUcboUzv/twfZU8fIBbTOphRAe0v8EyxzeDpKXqGHfyDA==
   dependencies:
     "@rollup/pluginutils" "^5.0.1"
     resolve "^1.22.1"
 
 "@rollup/pluginutils@^5.0.1":
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-5.0.2.tgz#012b8f53c71e4f6f9cb317e311df1404f56e7a33"
-  integrity sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-5.0.5.tgz#bbb4c175e19ebfeeb8c132c2eea0ecb89941a66c"
+  integrity sha512-6aEYR910NyP73oHiJglti74iRyOwgFU4x3meH/H8OJx6Ry0j6cOVZ5X/wTvub7G7Ao6qaHBEaNsV3GLJkSsF+Q==
   dependencies:
     "@types/estree" "^1.0.0"
     estree-walker "^2.0.2"
     picomatch "^2.3.1"
-
-"@sinclair/typebox@^0.25.16":
-  version "0.25.23"
-  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.25.23.tgz#1c15b0d2b872d89cc0f47c7243eacb447df8b8bd"
-  integrity sha512-VEB8ygeP42CFLWyAJhN5OklpxUliqdNEUcXb4xZ/CINqtYGTjL5ukluKdKzQ0iWdUxyQ7B0539PAUhHKrCNWSQ==
 
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"
@@ -772,30 +732,30 @@
   dependencies:
     "@babel/types" "^7.20.7"
 
-"@types/chrome@^0.0.213":
-  version "0.0.213"
-  resolved "https://registry.yarnpkg.com/@types/chrome/-/chrome-0.0.213.tgz#f1e421f76ce7986d2886bafc6c359575e599471e"
-  integrity sha512-oDF+AGr2gcHzxX5xq8TjmLtnMnV3nL1ci4Y6CjhDqIKI8Ar36JOWnmQx6eGVBBYEX824OIN0NQwDo2cevEBbQQ==
+"@types/chrome@^0.0.248":
+  version "0.0.248"
+  resolved "https://registry.yarnpkg.com/@types/chrome/-/chrome-0.0.248.tgz#fdc188a4b7ab8cfd2c49cb666214ecab81599002"
+  integrity sha512-qtBzxZD1v3eWZn8XxH1i07pAhzJDHnxJBBVy7bmntXxXKxjzNXYxD41teqa5yOcX/Yy8brRFGZESEzGoINvBDg==
   dependencies:
     "@types/filesystem" "*"
     "@types/har-format" "*"
 
 "@types/estree@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.0.tgz#5fb2e536c1ae9bf35366eed879e827fa59ca41c2"
-  integrity sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.3.tgz#2be19e759a3dd18c79f9f436bd7363556c1a73dd"
+  integrity sha512-CS2rOaoQ/eAgAfcTfq6amKG7bsN+EMcgGY4FAFQdvSj2y1ixvOZTUA9mOtCai7E1SYu283XNw7urKK30nP3wkQ==
 
 "@types/filesystem@*":
-  version "0.0.32"
-  resolved "https://registry.yarnpkg.com/@types/filesystem/-/filesystem-0.0.32.tgz#307df7cc084a2293c3c1a31151b178063e0a8edf"
-  integrity sha512-Yuf4jR5YYMR2DVgwuCiP11s0xuVRyPKmz8vo6HBY3CGdeMj8af93CFZX+T82+VD1+UqHOxTq31lO7MI7lepBtQ==
+  version "0.0.34"
+  resolved "https://registry.yarnpkg.com/@types/filesystem/-/filesystem-0.0.34.tgz#9b0d0d791ab6b217528cce8d391764b4b47607bf"
+  integrity sha512-La4bGrgck8/rosDUA1DJJP8hrFcKq0BV6JaaVlNnOo1rJdJDcft3//slEbAmsWNUJwXRCc0DXpeO40yuATlexw==
   dependencies:
     "@types/filewriter" "*"
 
 "@types/filewriter@*":
-  version "0.0.29"
-  resolved "https://registry.yarnpkg.com/@types/filewriter/-/filewriter-0.0.29.tgz#a48795ecadf957f6c0d10e0c34af86c098fa5bee"
-  integrity sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ==
+  version "0.0.31"
+  resolved "https://registry.yarnpkg.com/@types/filewriter/-/filewriter-0.0.31.tgz#a5a256646bd98209baf9aa32073047f84f4c3f3f"
+  integrity sha512-12df1utOvPC80+UaVoOO1d81X8pa5MefHNS+gWX9R2ucSESpMz9K5QwlTWDGKASrzCpSFwj7NPYh+nTsolgEGA==
 
 "@types/graceful-fs@^4.1.3":
   version "4.1.8"
@@ -805,9 +765,9 @@
     "@types/node" "*"
 
 "@types/har-format@*":
-  version "1.2.10"
-  resolved "https://registry.yarnpkg.com/@types/har-format/-/har-format-1.2.10.tgz#7b4e1e0ada4d17684ac3b05d601a4871cfab11fc"
-  integrity sha512-o0J30wqycjF5miWDKYKKzzOU1ZTLuA42HZ4HE7/zqTOc/jTLdQ5NhYWvsRQo45Nfi1KHoRdNhteSI4BAxTF1Pg==
+  version "1.2.14"
+  resolved "https://registry.yarnpkg.com/@types/har-format/-/har-format-1.2.14.tgz#292e55d52be8659c8486316a0ae439760617e0a3"
+  integrity sha512-pEmBAoccWvO6XbSI8A7KvIDGEoKtlLWtdqVCKoVBcCDSFvR4Ijd7zGLu7MWGEqk2r8D54uWlMRt+VZuSrfFMzQ==
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.5"
@@ -829,9 +789,9 @@
     "@types/istanbul-lib-report" "*"
 
 "@types/jest@^29.4.0":
-  version "29.4.0"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.4.0.tgz#a8444ad1704493e84dbf07bb05990b275b3b9206"
-  integrity sha512-VaywcGQ9tPorCX/Jkkni7RWGFfI11whqzs8dvxF41P17Z+z872thvEvlIbznjPJ02kl1HMX3LmLOonsj2n7HeQ==
+  version "29.5.6"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.6.tgz#f4cf7ef1b5b0bfc1aa744e41b24d9cc52533130b"
+  integrity sha512-/t9NnzkOpXb4Nfvg17ieHE6EeSjDS2SGSpNYfoLbUAeL/EOueU/RSdOWFpfQTXBEM7BguYW1XQ0EbM+6RlIh6w==
   dependencies:
     expect "^29.0.0"
     pretty-format "^29.0.0"
@@ -845,10 +805,10 @@
     "@types/tough-cookie" "*"
     parse5 "^7.0.0"
 
-"@types/json-schema@^7.0.9":
-  version "7.0.11"
-  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
-  integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
+"@types/json-schema@^7.0.12":
+  version "7.0.14"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.14.tgz#74a97a5573980802f32c8e47b663530ab3b6b7d1"
+  integrity sha512-U3PUjAudAdJBeC2pgN8uTIKgxrb4nlDF3SF0++EldXQvQBGkpFZMSnwQiIoDU77tv45VgNkl/L4ouD+rEomujw==
 
 "@types/node@*":
   version "20.8.7"
@@ -857,10 +817,10 @@
   dependencies:
     undici-types "~5.25.1"
 
-"@types/semver@^7.3.12":
-  version "7.3.13"
-  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
-  integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
+"@types/semver@^7.5.0":
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.4.tgz#0a41252ad431c473158b22f9bfb9a63df7541cff"
+  integrity sha512-MMzuxN3GdFwskAnb6fz0orFvhfqi752yjaXylr0Rp4oDg5H0Zn1IuyRhDVvYOwAXoJirx2xuS16I3WjxnAIHiQ==
 
 "@types/stack-utils@^2.0.0":
   version "2.0.2"
@@ -868,9 +828,9 @@
   integrity sha512-g7CK9nHdwjK2n0ymT2CW698FuWJRIx+RP6embAzZ2Qi8/ilIrA1Imt2LVSeHUzKvpoi7BhmmQcXz95eS0f2JXw==
 
 "@types/tough-cookie@*":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.2.tgz#6286b4c7228d58ab7866d19716f3696e03a09397"
-  integrity sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.4.tgz#cf2f0c7c51b985b6afecea73eb2cd65421ecb717"
+  integrity sha512-95Sfz4nvMAb0Nl9DTxN3j64adfwfbBPEYq14VN7zT5J5O2M9V6iZMIIQU1U+pJyl9agHYHNCqhCXgyEtIRRa5A==
 
 "@types/yargs-parser@*":
   version "21.0.2"
@@ -884,89 +844,95 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^5.52.0":
-  version "5.52.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.52.0.tgz#5fb0d43574c2411f16ea80f5fc335b8eaa7b28a8"
-  integrity sha512-lHazYdvYVsBokwCdKOppvYJKaJ4S41CgKBcPvyd0xjZNbvQdhn/pnJlGtQksQ/NhInzdaeaSarlBjDXHuclEbg==
+"@typescript-eslint/eslint-plugin@^6.8.0":
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.8.0.tgz#06abe4265e7c82f20ade2dcc0e3403c32d4f148b"
+  integrity sha512-GosF4238Tkes2SHPQ1i8f6rMtG6zlKwMEB0abqSJ3Npvos+doIlc/ATG+vX1G9coDF3Ex78zM3heXHLyWEwLUw==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.52.0"
-    "@typescript-eslint/type-utils" "5.52.0"
-    "@typescript-eslint/utils" "5.52.0"
+    "@eslint-community/regexpp" "^4.5.1"
+    "@typescript-eslint/scope-manager" "6.8.0"
+    "@typescript-eslint/type-utils" "6.8.0"
+    "@typescript-eslint/utils" "6.8.0"
+    "@typescript-eslint/visitor-keys" "6.8.0"
     debug "^4.3.4"
-    grapheme-splitter "^1.0.4"
-    ignore "^5.2.0"
-    natural-compare-lite "^1.4.0"
-    regexpp "^3.2.0"
-    semver "^7.3.7"
-    tsutils "^3.21.0"
+    graphemer "^1.4.0"
+    ignore "^5.2.4"
+    natural-compare "^1.4.0"
+    semver "^7.5.4"
+    ts-api-utils "^1.0.1"
 
-"@typescript-eslint/parser@^5.52.0":
-  version "5.52.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.52.0.tgz#73c136df6c0133f1d7870de7131ccf356f5be5a4"
-  integrity sha512-e2KiLQOZRo4Y0D/b+3y08i3jsekoSkOYStROYmPUnGMEoA0h+k2qOH5H6tcjIc68WDvGwH+PaOrP1XRzLJ6QlA==
+"@typescript-eslint/parser@^6.8.0":
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-6.8.0.tgz#bb2a969d583db242f1ee64467542f8b05c2e28cb"
+  integrity sha512-5tNs6Bw0j6BdWuP8Fx+VH4G9fEPDxnVI7yH1IAPkQH5RUtvKwRoqdecAPdQXv4rSOADAaz1LFBZvZG7VbXivSg==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.52.0"
-    "@typescript-eslint/types" "5.52.0"
-    "@typescript-eslint/typescript-estree" "5.52.0"
+    "@typescript-eslint/scope-manager" "6.8.0"
+    "@typescript-eslint/types" "6.8.0"
+    "@typescript-eslint/typescript-estree" "6.8.0"
+    "@typescript-eslint/visitor-keys" "6.8.0"
     debug "^4.3.4"
 
-"@typescript-eslint/scope-manager@5.52.0":
-  version "5.52.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.52.0.tgz#a993d89a0556ea16811db48eabd7c5b72dcb83d1"
-  integrity sha512-AR7sxxfBKiNV0FWBSARxM8DmNxrwgnYMPwmpkC1Pl1n+eT8/I2NAUPuwDy/FmDcC6F8pBfmOcaxcxRHspgOBMw==
+"@typescript-eslint/scope-manager@6.8.0":
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-6.8.0.tgz#5cac7977385cde068ab30686889dd59879811efd"
+  integrity sha512-xe0HNBVwCph7rak+ZHcFD6A+q50SMsFwcmfdjs9Kz4qDh5hWhaPhFjRs/SODEhroBI5Ruyvyz9LfwUJ624O40g==
   dependencies:
-    "@typescript-eslint/types" "5.52.0"
-    "@typescript-eslint/visitor-keys" "5.52.0"
+    "@typescript-eslint/types" "6.8.0"
+    "@typescript-eslint/visitor-keys" "6.8.0"
 
-"@typescript-eslint/type-utils@5.52.0":
-  version "5.52.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.52.0.tgz#9fd28cd02e6f21f5109e35496df41893f33167aa"
-  integrity sha512-tEKuUHfDOv852QGlpPtB3lHOoig5pyFQN/cUiZtpw99D93nEBjexRLre5sQZlkMoHry/lZr8qDAt2oAHLKA6Jw==
+"@typescript-eslint/type-utils@6.8.0":
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-6.8.0.tgz#50365e44918ca0fd159844b5d6ea96789731e11f"
+  integrity sha512-RYOJdlkTJIXW7GSldUIHqc/Hkto8E+fZN96dMIFhuTJcQwdRoGN2rEWA8U6oXbLo0qufH7NPElUb+MceHtz54g==
   dependencies:
-    "@typescript-eslint/typescript-estree" "5.52.0"
-    "@typescript-eslint/utils" "5.52.0"
+    "@typescript-eslint/typescript-estree" "6.8.0"
+    "@typescript-eslint/utils" "6.8.0"
     debug "^4.3.4"
-    tsutils "^3.21.0"
+    ts-api-utils "^1.0.1"
 
-"@typescript-eslint/types@5.52.0":
-  version "5.52.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.52.0.tgz#19e9abc6afb5bd37a1a9bea877a1a836c0b3241b"
-  integrity sha512-oV7XU4CHYfBhk78fS7tkum+/Dpgsfi91IIDy7fjCyq2k6KB63M6gMC0YIvy+iABzmXThCRI6xpCEyVObBdWSDQ==
+"@typescript-eslint/types@6.8.0":
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-6.8.0.tgz#1ab5d4fe1d613e3f65f6684026ade6b94f7e3ded"
+  integrity sha512-p5qOxSum7W3k+llc7owEStXlGmSl8FcGvhYt8Vjy7FqEnmkCVlM3P57XQEGj58oqaBWDQXbJDZxwUWMS/EAPNQ==
 
-"@typescript-eslint/typescript-estree@5.52.0":
-  version "5.52.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.52.0.tgz#6408cb3c2ccc01c03c278cb201cf07e73347dfca"
-  integrity sha512-WeWnjanyEwt6+fVrSR0MYgEpUAuROxuAH516WPjUblIrClzYJj0kBbjdnbQXLpgAN8qbEuGywiQsXUVDiAoEuQ==
+"@typescript-eslint/typescript-estree@6.8.0":
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-6.8.0.tgz#9565f15e0cd12f55cf5aa0dfb130a6cb0d436ba1"
+  integrity sha512-ISgV0lQ8XgW+mvv5My/+iTUdRmGspducmQcDw5JxznasXNnZn3SKNrTRuMsEXv+V/O+Lw9AGcQCfVaOPCAk/Zg==
   dependencies:
-    "@typescript-eslint/types" "5.52.0"
-    "@typescript-eslint/visitor-keys" "5.52.0"
+    "@typescript-eslint/types" "6.8.0"
+    "@typescript-eslint/visitor-keys" "6.8.0"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
-    semver "^7.3.7"
-    tsutils "^3.21.0"
+    semver "^7.5.4"
+    ts-api-utils "^1.0.1"
 
-"@typescript-eslint/utils@5.52.0":
-  version "5.52.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.52.0.tgz#b260bb5a8f6b00a0ed51db66bdba4ed5e4845a72"
-  integrity sha512-As3lChhrbwWQLNk2HC8Ree96hldKIqk98EYvypd3It8Q1f8d5zWyIoaZEp2va5667M4ZyE7X8UUR+azXrFl+NA==
+"@typescript-eslint/utils@6.8.0":
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-6.8.0.tgz#d42939c2074c6b59844d0982ce26a51d136c4029"
+  integrity sha512-dKs1itdE2qFG4jr0dlYLQVppqTE+Itt7GmIf/vX6CSvsW+3ov8PbWauVKyyfNngokhIO9sKZeRGCUo1+N7U98Q==
   dependencies:
-    "@types/json-schema" "^7.0.9"
-    "@types/semver" "^7.3.12"
-    "@typescript-eslint/scope-manager" "5.52.0"
-    "@typescript-eslint/types" "5.52.0"
-    "@typescript-eslint/typescript-estree" "5.52.0"
-    eslint-scope "^5.1.1"
-    eslint-utils "^3.0.0"
-    semver "^7.3.7"
+    "@eslint-community/eslint-utils" "^4.4.0"
+    "@types/json-schema" "^7.0.12"
+    "@types/semver" "^7.5.0"
+    "@typescript-eslint/scope-manager" "6.8.0"
+    "@typescript-eslint/types" "6.8.0"
+    "@typescript-eslint/typescript-estree" "6.8.0"
+    semver "^7.5.4"
 
-"@typescript-eslint/visitor-keys@5.52.0":
-  version "5.52.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.52.0.tgz#e38c971259f44f80cfe49d97dbffa38e3e75030f"
-  integrity sha512-qMwpw6SU5VHCPr99y274xhbm+PRViK/NATY6qzt+Et7+mThGuFSl/ompj2/hrBlRP/kq+BFdgagnOSgw9TB0eA==
+"@typescript-eslint/visitor-keys@6.8.0":
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-6.8.0.tgz#cffebed56ae99c45eba901c378a6447b06be58b8"
+  integrity sha512-oqAnbA7c+pgOhW2OhGvxm0t1BULX5peQI/rLsNDpGM78EebV3C9IGbX5HNZabuZ6UQrYveCLjKo8Iy/lLlBkkg==
   dependencies:
-    "@typescript-eslint/types" "5.52.0"
-    eslint-visitor-keys "^3.3.0"
+    "@typescript-eslint/types" "6.8.0"
+    eslint-visitor-keys "^3.4.1"
+
+"@ungap/structured-clone@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
+  integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
 abab@^2.0.6:
   version "2.0.6"
@@ -996,15 +962,10 @@ acorn@^7.4.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-acorn@^8.1.0, acorn@^8.8.1:
+acorn@^8.1.0, acorn@^8.8.1, acorn@^8.9.0:
   version "8.10.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.10.0.tgz#8be5b3907a67221a81ab23c7889c4c5526b62ec5"
   integrity sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==
-
-acorn@^8.8.0:
-  version "8.8.2"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.2.tgz#1b2f25db02af965399b9776b0c2c391276d37c4a"
-  integrity sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==
 
 agent-base@6:
   version "6.0.2"
@@ -1024,9 +985,9 @@ ajv@^6.10.0, ajv@^6.12.4:
     uri-js "^4.2.2"
 
 ajv@^8.0.1:
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.6.2.tgz#2fb45e0e5fcbc0813326c1c3da535d1881bb0571"
-  integrity sha512-9807RlWAgT564wT+DjeyU5OFMPjmzxVobvDFmNAhY+5zD6A2ly3jDp6sgnfyDtlIQ+7H97oc/DGCzzfu9rjw9w==
+  version "8.12.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
+  integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"
@@ -1034,9 +995,9 @@ ajv@^8.0.1:
     uri-js "^4.2.2"
 
 ansi-colors@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
-  integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.3.tgz#37611340eb2243e70cc604cad35d63270d48781b"
+  integrity sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==
 
 ansi-escapes@^4.2.1:
   version "4.3.2"
@@ -1233,7 +1194,7 @@ caniuse-lite@^1.0.30001541:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001551.tgz#1f2cfa8820bd97c971a57349d7fd8f6e08664a3e"
   integrity sha512-vtBAez47BoGMMzlbYhfXrMV1kvRF2WP/lqiMuDu1Sb4EE4LKEgjopFDSRtZfdVnslNRpOqV/woE+Xgrwj6VQlg==
 
-chalk@^2.0.0, chalk@^2.4.2:
+chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -1373,17 +1334,10 @@ data-urls@^3.0.2:
     whatwg-mimetype "^3.0.0"
     whatwg-url "^11.0.0"
 
-debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
+debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
-  dependencies:
-    ms "2.1.2"
-
-debug@^4.0.1:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
-  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
   dependencies:
     ms "2.1.2"
 
@@ -1398,9 +1352,9 @@ dedent@^1.0.0:
   integrity sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==
 
 deep-is@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
-  integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
+  integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
 deepmerge@^4.2.2:
   version "4.3.1"
@@ -1417,7 +1371,7 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-diff-sequences@^29.4.3, diff-sequences@^29.6.3:
+diff-sequences@^29.6.3:
   version "29.6.3"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.6.3.tgz#4deaf894d11407c51efc8418012f9e70b84ea921"
   integrity sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==
@@ -1444,9 +1398,9 @@ domexception@^4.0.0:
     webidl-conversions "^7.0.0"
 
 electron-to-chromium@^1.4.535:
-  version "1.4.562"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.562.tgz#7502b8cafbb7cc59701b17e744fa6ef5f7fe2b96"
-  integrity sha512-kMGVZLP65O2/oH7zzaoIA5hcr4/xPYO6Sa83FrIpWcd7YPPtSlxqwxTd8lJIwKxaiXM6FGsYK4ukyJ40XkW7jg==
+  version "1.4.563"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.563.tgz#dabb424202754c1fed2d2938ff564b23d3bbf0d3"
+  integrity sha512-dg5gj5qOgfZNkPNeyKBZQAQitIQ/xwfIDmEQJHCbXaD9ebTZxwJXUsDYcBlAvZGZLi+/354l35J1wkmP6CqYaw==
 
 emittery@^0.13.1:
   version "0.13.1"
@@ -1459,11 +1413,12 @@ emoji-regex@^8.0.0:
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
 enquirer@^2.3.5:
-  version "2.3.6"
-  resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
-  integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.4.1.tgz#93334b3fbd74fc7097b224ab4a8fb7e40bf4ae56"
+  integrity sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==
   dependencies:
     ansi-colors "^4.1.1"
+    strip-ansi "^6.0.1"
 
 entities@^4.4.0:
   version "4.5.0"
@@ -1516,10 +1471,10 @@ eslint-scope@^5.1.1:
     esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
-eslint-scope@^7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.2.0.tgz#f21ebdafda02352f103634b96dd47d9f81ca117b"
-  integrity sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==
+eslint-scope@^7.2.2:
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.2.2.tgz#deb4f92563390f32006894af62a22dba1c46423f"
+  integrity sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==
   dependencies:
     esrecurse "^4.3.0"
     estraverse "^5.2.0"
@@ -1531,13 +1486,6 @@ eslint-utils@^2.1.0:
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
-eslint-utils@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-3.0.0.tgz#8aebaface7345bb33559db0a1f13a1d2d48c3672"
-  integrity sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==
-  dependencies:
-    eslint-visitor-keys "^2.0.0"
-
 eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
@@ -1548,15 +1496,10 @@ eslint-visitor-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
-eslint-visitor-keys@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
-  integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
-
-eslint-visitor-keys@^3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz#c22c48f48942d08ca824cc526211ae400478a994"
-  integrity sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==
+eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4.3:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
+  integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
 eslint@^7.32.0:
   version "7.32.0"
@@ -1605,26 +1548,27 @@ eslint@^7.32.0:
     v8-compile-cache "^2.0.3"
 
 eslint@^8.24.0:
-  version "8.40.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.40.0.tgz#a564cd0099f38542c4e9a2f630fa45bf33bc42a4"
-  integrity sha512-bvR+TsP9EHL3TqNtj9sCNJVAFK3fBN8Q7g5waghxyRsPLIMwL73XSKnZFK0hk/O2ANC+iAoq6PWMQ+IfBAJIiQ==
+  version "8.52.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.52.0.tgz#d0cd4a1fac06427a61ef9242b9353f36ea7062fc"
+  integrity sha512-zh/JHnaixqHZsolRB/w9/02akBk9EPrOs9JwcTP2ek7yL5bVvXuRariiaAjjoJ5DvuwQ1WAE/HsMz+w17YgBCg==
   dependencies:
     "@eslint-community/eslint-utils" "^4.2.0"
-    "@eslint-community/regexpp" "^4.4.0"
-    "@eslint/eslintrc" "^2.0.3"
-    "@eslint/js" "8.40.0"
-    "@humanwhocodes/config-array" "^0.11.8"
+    "@eslint-community/regexpp" "^4.6.1"
+    "@eslint/eslintrc" "^2.1.2"
+    "@eslint/js" "8.52.0"
+    "@humanwhocodes/config-array" "^0.11.13"
     "@humanwhocodes/module-importer" "^1.0.1"
     "@nodelib/fs.walk" "^1.2.8"
-    ajv "^6.10.0"
+    "@ungap/structured-clone" "^1.2.0"
+    ajv "^6.12.4"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
     debug "^4.3.2"
     doctrine "^3.0.0"
     escape-string-regexp "^4.0.0"
-    eslint-scope "^7.2.0"
-    eslint-visitor-keys "^3.4.1"
-    espree "^9.5.2"
+    eslint-scope "^7.2.2"
+    eslint-visitor-keys "^3.4.3"
+    espree "^9.6.1"
     esquery "^1.4.2"
     esutils "^2.0.2"
     fast-deep-equal "^3.1.3"
@@ -1632,22 +1576,19 @@ eslint@^8.24.0:
     find-up "^5.0.0"
     glob-parent "^6.0.2"
     globals "^13.19.0"
-    grapheme-splitter "^1.0.4"
+    graphemer "^1.4.0"
     ignore "^5.2.0"
-    import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
     is-glob "^4.0.0"
     is-path-inside "^3.0.3"
-    js-sdsl "^4.1.4"
     js-yaml "^4.1.0"
     json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.4.1"
     lodash.merge "^4.6.2"
     minimatch "^3.1.2"
     natural-compare "^1.4.0"
-    optionator "^0.9.1"
+    optionator "^0.9.3"
     strip-ansi "^6.0.1"
-    strip-json-comments "^3.1.0"
     text-table "^0.2.0"
 
 espree@^7.3.0, espree@^7.3.1:
@@ -1659,12 +1600,12 @@ espree@^7.3.0, espree@^7.3.1:
     acorn-jsx "^5.3.1"
     eslint-visitor-keys "^1.3.0"
 
-espree@^9.5.2:
-  version "9.5.2"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-9.5.2.tgz#e994e7dc33a082a7a82dceaf12883a829353215b"
-  integrity sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==
+espree@^9.6.0, espree@^9.6.1:
+  version "9.6.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-9.6.1.tgz#a2a17b8e434690a5432f2f8018ce71d331a48c6f"
+  integrity sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==
   dependencies:
-    acorn "^8.8.0"
+    acorn "^8.9.0"
     acorn-jsx "^5.3.2"
     eslint-visitor-keys "^3.4.1"
 
@@ -1673,14 +1614,7 @@ esprima@^4.0.0, esprima@^4.0.1:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-esquery@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.0.tgz#2148ffc38b82e8c7057dfed48425b3e61f0f24a5"
-  integrity sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==
-  dependencies:
-    estraverse "^5.1.0"
-
-esquery@^1.4.2:
+esquery@^1.4.0, esquery@^1.4.2:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.5.0.tgz#6ce17738de8577694edd7361c57182ac8cb0db0b"
   integrity sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==
@@ -1699,12 +1633,7 @@ estraverse@^4.1.1:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
-estraverse@^5.1.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
-  integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
-
-estraverse@^5.2.0:
+estraverse@^5.1.0, estraverse@^5.2.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
@@ -1739,18 +1668,7 @@ exit@^0.1.2:
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
   integrity sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==
 
-expect@^29.0.0:
-  version "29.4.3"
-  resolved "https://registry.yarnpkg.com/expect/-/expect-29.4.3.tgz#5e47757316df744fe3b8926c3ae8a3ebdafff7fe"
-  integrity sha512-uC05+Q7eXECFpgDrHdXA4k2rpMyStAYPItEDLyQDo5Ta7fVkJnNA/4zh/OIVkVVNZ1oOK1PipQoyNjuZ6sz6Dg==
-  dependencies:
-    "@jest/expect-utils" "^29.4.3"
-    jest-get-type "^29.4.3"
-    jest-matcher-utils "^29.4.3"
-    jest-message-util "^29.4.3"
-    jest-util "^29.4.3"
-
-expect@^29.7.0:
+expect@^29.0.0, expect@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/expect/-/expect-29.7.0.tgz#578874590dcb3214514084c08115d8aee61e11bc"
   integrity sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==
@@ -1767,9 +1685,9 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
 fast-glob@^3.2.9:
-  version "3.2.12"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
-  integrity sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.1.tgz#784b4e897340f3dbbef17413b3f11acf03c874c4"
+  integrity sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
@@ -1785,7 +1703,7 @@ fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0, fast-json-sta
 fast-levenshtein@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
-  integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+  integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
 fastq@^1.6.0:
   version "1.15.0"
@@ -1832,17 +1750,18 @@ find-up@^5.0.0:
     path-exists "^4.0.0"
 
 flat-cache@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
-  integrity sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.1.1.tgz#a02a15fdec25a8f844ff7cc658f03dd99eb4609b"
+  integrity sha512-/qM2b3LUIaIgviBQovTLvijfyOQXPtSRnRK26ksj2J7rzPIecePUIpJsZ4T02Qg+xiAEKIs5K8dsHEd+VaKa/Q==
   dependencies:
-    flatted "^3.1.0"
+    flatted "^3.2.9"
+    keyv "^4.5.3"
     rimraf "^3.0.2"
 
-flatted@^3.1.0:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.2.tgz#64bfed5cb68fe3ca78b3eb214ad97b63bedce561"
-  integrity sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==
+flatted@^3.2.9:
+  version "3.2.9"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.9.tgz#7eb4c67ca1ba34232ca9d2d93e9886e611ad7daf"
+  integrity sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==
 
 form-data@^4.0.0:
   version "4.0.0"
@@ -1858,20 +1777,15 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@^2.3.2:
+fsevents@^2.3.2, fsevents@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
-fsevents@~2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
-  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
-
 functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
-  integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
+  integrity sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==
 
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
@@ -1924,17 +1838,10 @@ globals@^11.1.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
-globals@^13.19.0:
-  version "13.20.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-13.20.0.tgz#ea276a1e508ffd4f1612888f9d1bad1e2717bf82"
-  integrity sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==
-  dependencies:
-    type-fest "^0.20.2"
-
-globals@^13.6.0, globals@^13.9.0:
-  version "13.11.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-13.11.0.tgz#40ef678da117fe7bd2e28f1fab24951bd0255be7"
-  integrity sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==
+globals@^13.19.0, globals@^13.6.0, globals@^13.9.0:
+  version "13.23.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-13.23.0.tgz#ef31673c926a0976e1f61dab4dca57e0c0a8af02"
+  integrity sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==
   dependencies:
     type-fest "^0.20.2"
 
@@ -1955,10 +1862,10 @@ graceful-fs@^4.2.9:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
 
-grapheme-splitter@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz#9cf3a665c6247479896834af35cf1dbb4400767e"
-  integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
+graphemer@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
+  integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -2021,7 +1928,7 @@ ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.2.0:
+ignore@^5.2.0, ignore@^5.2.4:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
@@ -2065,7 +1972,7 @@ is-arrayish@^0.2.1:
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==
 
-is-core-module@^2.13.0, is-core-module@^2.9.0:
+is-core-module@^2.13.0:
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.13.0.tgz#bb52aa6e2cbd49a30c2ba68c42bf3435ba6072db"
   integrity sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==
@@ -2075,7 +1982,7 @@ is-core-module@^2.13.0, is-core-module@^2.9.0:
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
-  integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
+  integrity sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
 
 is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
@@ -2087,14 +1994,7 @@ is-generator-fn@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
-is-glob@^4.0.0, is-glob@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
-  integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
-  dependencies:
-    is-extglob "^2.1.1"
-
-is-glob@^4.0.3:
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
@@ -2259,16 +2159,6 @@ jest-config@^29.7.0:
     slash "^3.0.0"
     strip-json-comments "^3.1.1"
 
-jest-diff@^29.4.3:
-  version "29.4.3"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-29.4.3.tgz#42f4eb34d0bf8c0fb08b0501069b87e8e84df347"
-  integrity sha512-YB+ocenx7FZ3T5O9lMVMeLYV4265socJKtkwgk/6YUz/VsEzYDkiMuMhWzZmxm3wDRQvayJu/PjkjjSkjoHsCA==
-  dependencies:
-    chalk "^4.0.0"
-    diff-sequences "^29.4.3"
-    jest-get-type "^29.4.3"
-    pretty-format "^29.4.3"
-
 jest-diff@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-29.7.0.tgz#017934a66ebb7ecf6f205e84699be10afd70458a"
@@ -2298,17 +2188,17 @@ jest-each@^29.7.0:
     pretty-format "^29.7.0"
 
 jest-environment-jsdom@^29.0.0:
-  version "29.6.2"
-  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-29.6.2.tgz#4fc68836a7774a771819a2f980cb47af3b1629da"
-  integrity sha512-7oa/+266AAEgkzae8i1awNEfTfjwawWKLpiw2XesZmaoVVj9u9t8JOYx18cG29rbPNtkUlZ8V4b5Jb36y/VxoQ==
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz#d206fa3551933c3fd519e5dfdb58a0f5139a837f"
+  integrity sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==
   dependencies:
-    "@jest/environment" "^29.6.2"
-    "@jest/fake-timers" "^29.6.2"
-    "@jest/types" "^29.6.1"
+    "@jest/environment" "^29.7.0"
+    "@jest/fake-timers" "^29.7.0"
+    "@jest/types" "^29.6.3"
     "@types/jsdom" "^20.0.0"
     "@types/node" "*"
-    jest-mock "^29.6.2"
-    jest-util "^29.6.2"
+    jest-mock "^29.7.0"
+    jest-util "^29.7.0"
     jsdom "^20.0.0"
 
 jest-environment-node@^29.7.0:
@@ -2323,7 +2213,7 @@ jest-environment-node@^29.7.0:
     jest-mock "^29.7.0"
     jest-util "^29.7.0"
 
-jest-get-type@^29.4.3, jest-get-type@^29.6.3:
+jest-get-type@^29.6.3:
   version "29.6.3"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.6.3.tgz#36f499fdcea197c1045a127319c0481723908fd1"
   integrity sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==
@@ -2355,16 +2245,6 @@ jest-leak-detector@^29.7.0:
     jest-get-type "^29.6.3"
     pretty-format "^29.7.0"
 
-jest-matcher-utils@^29.4.3:
-  version "29.4.3"
-  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-29.4.3.tgz#ea68ebc0568aebea4c4213b99f169ff786df96a0"
-  integrity sha512-TTciiXEONycZ03h6R6pYiZlSkvYgT0l8aa49z/DLSGYjex4orMUcafuLXYyyEDWB1RKglq00jzwY00Ei7yFNVg==
-  dependencies:
-    chalk "^4.0.0"
-    jest-diff "^29.4.3"
-    jest-get-type "^29.4.3"
-    pretty-format "^29.4.3"
-
 jest-matcher-utils@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz#ae8fec79ff249fd592ce80e3ee474e83a6c44f12"
@@ -2374,21 +2254,6 @@ jest-matcher-utils@^29.7.0:
     jest-diff "^29.7.0"
     jest-get-type "^29.6.3"
     pretty-format "^29.7.0"
-
-jest-message-util@^29.4.3:
-  version "29.4.3"
-  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-29.4.3.tgz#65b5280c0fdc9419503b49d4f48d4999d481cb5b"
-  integrity sha512-1Y8Zd4ZCN7o/QnWdMmT76If8LuDv23Z1DRovBj/vcSFNlGCJGoO8D1nJDw1AdyAGUk0myDLFGN5RbNeJyCRGCw==
-  dependencies:
-    "@babel/code-frame" "^7.12.13"
-    "@jest/types" "^29.4.3"
-    "@types/stack-utils" "^2.0.0"
-    chalk "^4.0.0"
-    graceful-fs "^4.2.9"
-    micromatch "^4.0.4"
-    pretty-format "^29.4.3"
-    slash "^3.0.0"
-    stack-utils "^2.0.3"
 
 jest-message-util@^29.7.0:
   version "29.7.0"
@@ -2405,7 +2270,7 @@ jest-message-util@^29.7.0:
     slash "^3.0.0"
     stack-utils "^2.0.3"
 
-jest-mock@^29.6.2, jest-mock@^29.7.0:
+jest-mock@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-29.7.0.tgz#4e836cf60e99c6fcfabe9f99d017f3fdd50a6347"
   integrity sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==
@@ -2528,31 +2393,7 @@ jest-snapshot@^29.7.0:
     pretty-format "^29.7.0"
     semver "^7.5.3"
 
-jest-util@^29.0.0:
-  version "29.6.2"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-29.6.2.tgz#8a052df8fff2eebe446769fd88814521a517664d"
-  integrity sha512-3eX1qb6L88lJNCFlEADKOkjpXJQyZRiavX1INZ4tRnrBVr2COd3RgcTLyUiEXMNBlDU/cgYq6taUS0fExrWW4w==
-  dependencies:
-    "@jest/types" "^29.6.1"
-    "@types/node" "*"
-    chalk "^4.0.0"
-    ci-info "^3.2.0"
-    graceful-fs "^4.2.9"
-    picomatch "^2.2.3"
-
-jest-util@^29.4.3:
-  version "29.4.3"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-29.4.3.tgz#851a148e23fc2b633c55f6dad2e45d7f4579f496"
-  integrity sha512-ToSGORAz4SSSoqxDSylWX8JzkOQR7zoBtNRsA7e+1WUX5F8jrOwaNpuh1YfJHJKDHXLHmObv5eOjejUd+/Ws+Q==
-  dependencies:
-    "@jest/types" "^29.4.3"
-    "@types/node" "*"
-    chalk "^4.0.0"
-    ci-info "^3.2.0"
-    graceful-fs "^4.2.9"
-    picomatch "^2.2.3"
-
-jest-util@^29.6.2, jest-util@^29.7.0:
+jest-util@^29.0.0, jest-util@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-29.7.0.tgz#23c2b62bfb22be82b44de98055802ff3710fc0bc"
   integrity sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==
@@ -2609,11 +2450,6 @@ jest@^29.7.0:
     "@jest/types" "^29.6.3"
     import-local "^3.0.2"
     jest-cli "^29.7.0"
-
-js-sdsl@^4.1.4:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/js-sdsl/-/js-sdsl-4.4.0.tgz#8b437dbe642daa95760400b602378ed8ffea8430"
-  integrity sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==
 
 js-tokens@^4.0.0:
   version "4.0.0"
@@ -2672,6 +2508,11 @@ jsesc@^2.5.1:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
 
+json-buffer@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
+  integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
+
 json-parse-even-better-errors@^2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
@@ -2690,12 +2531,19 @@ json-schema-traverse@^1.0.0:
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
-  integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
+  integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
 json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
+
+keyv@^4.5.3:
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.4.tgz#a879a99e29452f942439f2a405e3af8b31d4de93"
+  integrity sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==
+  dependencies:
+    json-buffer "3.0.1"
 
 kleur@^3.0.3:
   version "3.0.3"
@@ -2734,11 +2582,6 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash.clonedeep@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
-  integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
-
 lodash.memoize@4.x:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
@@ -2752,7 +2595,7 @@ lodash.merge@^4.6.2:
 lodash.truncate@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
-  integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
+  integrity sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
 
 lru-cache@^5.1.1:
   version "5.1.1"
@@ -2834,11 +2677,6 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-natural-compare-lite@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz#17b09581988979fddafe0201e931ba933c96cbb4"
-  integrity sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==
-
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
@@ -2885,17 +2723,17 @@ onetime@^5.1.2:
   dependencies:
     mimic-fn "^2.1.0"
 
-optionator@^0.9.1:
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.1.tgz#4f236a6373dae0566a6d43e1326674f50c291499"
-  integrity sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==
+optionator@^0.9.1, optionator@^0.9.3:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.3.tgz#007397d44ed1872fdc6ed31360190f81814e2c64"
+  integrity sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==
   dependencies:
+    "@aashutoshrathi/word-wrap" "^1.2.3"
     deep-is "^0.1.3"
     fast-levenshtein "^2.0.6"
     levn "^0.4.1"
     prelude-ls "^1.2.1"
     type-check "^0.4.0"
-    word-wrap "^1.2.3"
 
 p-limit@^2.2.0:
   version "2.3.0"
@@ -3007,20 +2845,11 @@ prelude-ls@^1.2.1:
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
 prettier@^2.3.2:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
-  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
-pretty-format@^29.0.0, pretty-format@^29.4.3:
-  version "29.4.3"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.4.3.tgz#25500ada21a53c9e8423205cf0337056b201244c"
-  integrity sha512-cvpcHTc42lcsvOOAzd3XuNWTcvk1Jmnzqeu+WsOuiPmxUJTnkbAcFNsRKvEpBEUFVUgy/GTZLulZDcDEi+CIlA==
-  dependencies:
-    "@jest/schemas" "^29.4.3"
-    ansi-styles "^5.0.0"
-    react-is "^18.0.0"
-
-pretty-format@^29.7.0:
+pretty-format@^29.0.0, pretty-format@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.7.0.tgz#ca42c758310f365bfa71a0bda0a807160b776812"
   integrity sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==
@@ -3047,12 +2876,7 @@ psl@^1.1.33:
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
   integrity sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==
 
-punycode@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
-  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
-
-punycode@^2.1.1:
+punycode@^2.1.0, punycode@^2.1.1:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.0.tgz#f67fa67c94da8f4d0cfff981aee4118064199b8f"
   integrity sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==
@@ -3077,7 +2901,7 @@ react-is@^18.0.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
-regexpp@^3.1.0, regexpp@^3.2.0:
+regexpp@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
@@ -3119,21 +2943,12 @@ resolve.exports@^2.0.0:
   resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-2.0.2.tgz#f8c934b8e6a13f539e38b7098e2e36134f01e800"
   integrity sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==
 
-resolve@^1.20.0:
+resolve@^1.20.0, resolve@^1.22.1:
   version "1.22.8"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.8.tgz#b6c87a9f2aa06dfab52e3d70ac8cde321fa5a48d"
   integrity sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==
   dependencies:
     is-core-module "^2.13.0"
-    path-parse "^1.0.7"
-    supports-preserve-symlinks-flag "^1.0.0"
-
-resolve@^1.22.1:
-  version "1.22.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
-  integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
-  dependencies:
-    is-core-module "^2.9.0"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
@@ -3150,9 +2965,9 @@ rimraf@^3.0.2:
     glob "^7.1.3"
 
 rollup@^2.56.3:
-  version "2.56.3"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.56.3.tgz#b63edadd9851b0d618a6d0e6af8201955a77aeff"
-  integrity sha512-Au92NuznFklgQCUcV96iXlxUbHuB1vQMaH76DHl5M11TotjOHwqk9CwcrT78+Tnv4FN9uTBxq6p4EJoYkpyekg==
+  version "2.79.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.79.1.tgz#bedee8faef7c9f93a2647ac0108748f497f081c7"
+  integrity sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==
   optionalDependencies:
     fsevents "~2.3.2"
 
@@ -3180,21 +2995,7 @@ semver@^6.3.0, semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.2.1:
-  version "7.3.5"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
-  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
-  dependencies:
-    lru-cache "^6.0.0"
-
-semver@^7.3.7:
-  version "7.3.8"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
-  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
-  dependencies:
-    lru-cache "^6.0.0"
-
-semver@^7.5.3, semver@^7.5.4:
+semver@^7.2.1, semver@^7.5.3, semver@^7.5.4:
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
@@ -3333,16 +3134,15 @@ symbol-tree@^3.2.4:
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
 table@^6.0.9:
-  version "6.7.1"
-  resolved "https://registry.yarnpkg.com/table/-/table-6.7.1.tgz#ee05592b7143831a8c94f3cee6aae4c1ccef33e2"
-  integrity sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==
+  version "6.8.1"
+  resolved "https://registry.yarnpkg.com/table/-/table-6.8.1.tgz#ea2b71359fe03b017a5fbc296204471158080bdf"
+  integrity sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==
   dependencies:
     ajv "^8.0.1"
-    lodash.clonedeep "^4.5.0"
     lodash.truncate "^4.4.2"
     slice-ansi "^4.0.0"
-    string-width "^4.2.0"
-    strip-ansi "^6.0.0"
+    string-width "^4.2.3"
+    strip-ansi "^6.0.1"
 
 test-exclude@^6.0.0:
   version "6.0.0"
@@ -3356,7 +3156,7 @@ test-exclude@^6.0.0:
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
-  integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
+  integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
 
 tmpl@1.0.5:
   version "1.0.5"
@@ -3392,6 +3192,11 @@ tr46@^3.0.0:
   dependencies:
     punycode "^2.1.1"
 
+ts-api-utils@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-1.0.3.tgz#f12c1c781d04427313dbac808f453f050e54a331"
+  integrity sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==
+
 ts-jest@^29.0.0:
   version "29.1.1"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-29.1.1.tgz#f58fe62c63caf7bfcc5cc6472082f79180f0815b"
@@ -3406,22 +3211,10 @@ ts-jest@^29.0.0:
     semver "^7.5.3"
     yargs-parser "^21.0.1"
 
-tslib@^1.8.1:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
-  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
 tslib@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
-  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
-
-tsutils@^3.21.0:
-  version "3.21.0"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
-  integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
-  dependencies:
-    tslib "^1.8.1"
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
+  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
@@ -3445,10 +3238,10 @@ type-fest@^0.21.3:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
-typescript@^4.9.5:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
+  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
 
 undici-types@~5.25.1:
   version "5.25.3"
@@ -3484,9 +3277,9 @@ url-parse@^1.5.3:
     requires-port "^1.0.0"
 
 v8-compile-cache@^2.0.3:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
-  integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.4.0.tgz#cdada8bec61e15865f05d097c5f4fd30e94dc128"
+  integrity sha512-ocyWc3bAHBB/guyqJQVI5o4BZkPhznPYUG2ea80Gond/BgNWpap8TOmLSeeQG7bnh2KMISxskdADG59j7zruhw==
 
 v8-to-istanbul@^9.0.1:
   version "9.1.3"
@@ -3543,11 +3336,6 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-word-wrap@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
-  integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
-
 wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
@@ -3571,9 +3359,9 @@ write-file-atomic@^4.0.2:
     signal-exit "^3.0.7"
 
 ws@^8.11.0:
-  version "8.13.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.13.0.tgz#9a9fb92f93cf41512a0735c8f4dd09b8a1211cd0"
-  integrity sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==
+  version "8.14.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.14.2.tgz#6c249a806eb2db7a20d26d51e7709eab7b2e6c7f"
+  integrity sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==
 
 xml-name-validator@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
**Disclaimer**
Pulling the small thread of setting the `strict` flag in TSConfig turned in a gigantic PR. Additionally, my attempts at a reasonable commit history broke down after several rounds of fixes, cleanup, and debugging, so I ended up squashing to a single commit. If this is too much to review in one go, I can attempt to split it into more digestible chunks.

**Discussion**
I made some changes here that are not strictly required (pun intended) that I could change with some different assertions
- Split LOAD_MANIFEST into LOAD_MANIFEST and LOAD_COMPANY_MANIFEST. These two actions really are different, even though they have similar purpose, and most importantly they have different params.
- Converted `handleMessages` into a switch statement which allows us to check exhaustively that we're handling all message types and is a bit easier to read.
- There are a few places where we could potentially have exceptions due to missing data, I've added a `invalidateAndThrow` that attempts to make the failures more obvious when debugging, and also ensure that the extension doesn't just hang in the PROCESSING state.
- Added some helper methods for working with nested data structures.

**Validation**
- Build is clean.
- Tests pass.
- Verified a green checkmark on Facebook, Messenger, Instagram and WhatsApp on latest Chrome, Firefox and Edge.
