### PR TITLE
Add reason to CSP checker returns

### DIFF
--- a/src/js/__tests__/checkDocumentCSPHeaders-test.js
+++ b/src/js/__tests__/checkDocumentCSPHeaders-test.js
@@ -13,14 +13,14 @@ import {checkCSPForEvals} from '../content/checkCSPForEvals';
 import {ORIGIN_TYPE} from '../config';
 import {setCurrentOrigin} from '../content/updateCurrentState';
 
-describe('checkDocumentCSPHeaders', () => {
+describe('checkCSPForEvals', () => {
   beforeEach(() => {
     window.chrome.runtime.sendMessage = jest.fn(() => {});
     setCurrentOrigin('FACEBOOK');
   });
   describe('Enforce precedence', () => {
     it('Enforce valid policy from script-src', () => {
-      const isValid = checkCSPForEvals(
+      const [isValid] = checkCSPForEvals(
         [
           `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
             `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';`,
@@ -31,7 +31,7 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeTruthy();
     });
     it('Enforce valid policy from default-src', () => {
-      const isValid = checkCSPForEvals(
+      const [isValid] = checkCSPForEvals(
         [
           `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';`,
         ],
@@ -41,7 +41,7 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeTruthy();
     });
     it('Enforce invalid due to script-src, missing Report policy', () => {
-      const isValid = checkCSPForEvals(
+      const [isValid] = checkCSPForEvals(
         [
           `default-src data: blob: 'self' *.facebook.com *.fbcdn.net;` +
             `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
@@ -52,7 +52,7 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeFalsy();
     });
     it('Enforce invalid due to default-src, missing Report policy', () => {
-      const isValid = checkCSPForEvals(
+      const [isValid] = checkCSPForEvals(
         [
           `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'unsafe-eval';`,
         ],
@@ -64,7 +64,7 @@ describe('checkDocumentCSPHeaders', () => {
   });
   describe('Report affecting outcome', () => {
     it('Enforce invalid, correct Report policy because of script-src', () => {
-      const isValid = checkCSPForEvals(
+      const [isValid] = checkCSPForEvals(
         [],
         [
           `default-src data: blob: 'self' *.facebook.com *.fbcdn.net;` +
@@ -75,7 +75,7 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeTruthy();
     });
     it('Enforce invalid, correct Report policy because of default-src', () => {
-      const isValid = checkCSPForEvals(
+      const [isValid] = checkCSPForEvals(
         [],
         [`default-src data: blob: 'self' *.facebook.com *.fbcdn.net;`],
         ORIGIN_TYPE.FACEBOOK,
@@ -83,7 +83,7 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeTruthy();
     });
     it('Enforce invalid, incorrect Report policy because of script-src', () => {
-      const isValid = checkCSPForEvals(
+      const [isValid] = checkCSPForEvals(
         [],
         [
           `default-src data: blob: 'self' *.facebook.com *.fbcdn.net;` +
@@ -94,7 +94,7 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeFalsy();
     });
     it('Enforce invalid, incorrect Report policy because of default-src', () => {
-      const isValid = checkCSPForEvals(
+      const [isValid] = checkCSPForEvals(
         [],
         [
           `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'unsafe-eval';`,
@@ -106,7 +106,7 @@ describe('checkDocumentCSPHeaders', () => {
   });
   describe('Multiple policies, enforcement', () => {
     it('Should be valid if one of the policies is enforcing, both script-src', () => {
-      const isValid = checkCSPForEvals(
+      const [isValid] = checkCSPForEvals(
         [
           `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';` +
             'worker-src *.facebook.com/worker_url;',
@@ -118,7 +118,7 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeTruthy();
     });
     it('Should be valid if one of the policies is enforcing, both default-src', () => {
-      const isValid = checkCSPForEvals(
+      const [isValid] = checkCSPForEvals(
         [
           `default-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';` +
             'worker-src *.facebook.com/worker_url;',
@@ -130,7 +130,7 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeTruthy();
     });
     it('Should be valid if one of the policies is enforcing, script-src precedence', () => {
-      const isValid = checkCSPForEvals(
+      const [isValid] = checkCSPForEvals(
         [
           `default-src 'unsafe-eval';` +
             'worker-src *.facebook.com/worker_url;',
@@ -142,7 +142,7 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeTruthy();
     });
     it('Should be valid if one of the policies is enforcing, script-src precedence', () => {
-      const isValid = checkCSPForEvals(
+      const [isValid] = checkCSPForEvals(
         [
           ``,
           `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';`,
@@ -153,7 +153,7 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeTruthy();
     });
     it('Should be valid if one of the policies is enforcing, default-src precedence', () => {
-      const isValid = checkCSPForEvals(
+      const [isValid] = checkCSPForEvals(
         [
           ``,
           `default-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';`,
@@ -164,7 +164,7 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeTruthy();
     });
     it('Should be invalid if policy with precedence is not enforcing, script-src precedence', () => {
-      const isValid = checkCSPForEvals(
+      const [isValid] = checkCSPForEvals(
         [
           `default-src *.facebook.com;`,
           `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
@@ -175,7 +175,7 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeFalsy();
     });
     it('Should be invalid if none of the policies are enforcing, script-src precedence', () => {
-      const isValid = checkCSPForEvals(
+      const [isValid] = checkCSPForEvals(
         [
           `default-src *.facebook.com;` +
             `script-src *.facebook.com 'unsafe-eval';`,
@@ -189,7 +189,7 @@ describe('checkDocumentCSPHeaders', () => {
   });
   describe('Multiple policies, report-only', () => {
     it('Should be valid if one of the policies is reporting, both script-src', () => {
-      const isValid = checkCSPForEvals(
+      const [isValid] = checkCSPForEvals(
         [],
         [
           `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
@@ -200,7 +200,7 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeTruthy();
     });
     it('Should be valid if one of the policies is reporting, both default-src', () => {
-      const isValid = checkCSPForEvals(
+      const [isValid] = checkCSPForEvals(
         [],
         [
           `default-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
@@ -211,7 +211,7 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeTruthy();
     });
     it('Should be valid if one of the policies is reporting, script-src precedence', () => {
-      const isValid = checkCSPForEvals(
+      const [isValid] = checkCSPForEvals(
         [],
         [
           `default-src 'unsafe-eval';`,
@@ -222,7 +222,7 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeTruthy();
     });
     it('Should be valid if one of the policies is reporting, script-src precedence', () => {
-      const isValid = checkCSPForEvals(
+      const [isValid] = checkCSPForEvals(
         [],
         [``, `script-src *.facebook.com *.fbcdn.net blob: data: 'self';`],
         ORIGIN_TYPE.FACEBOOK,
@@ -230,7 +230,7 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeTruthy();
     });
     it('Should be valid if one of the policies is reporting, default-src precedence', () => {
-      const isValid = checkCSPForEvals(
+      const [isValid] = checkCSPForEvals(
         [],
         [``, `default-src *.facebook.com *.fbcdn.net blob: data: 'self';`],
         ORIGIN_TYPE.FACEBOOK,
@@ -238,7 +238,7 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeTruthy();
     });
     it('Should be invalid if policy with precedence is not reporting, script-src precedence', () => {
-      const isValid = checkCSPForEvals(
+      const [isValid] = checkCSPForEvals(
         [],
         [
           `default-src *.facebook.com;`,
@@ -249,7 +249,7 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeFalsy();
     });
     it('Should be invalid if none of the policies are reporting, script-src precedence', () => {
-      const isValid = checkCSPForEvals(
+      const [isValid] = checkCSPForEvals(
         [],
         [
           `default-src *.facebook.com;` +
@@ -263,99 +263,91 @@ describe('checkDocumentCSPHeaders', () => {
   });
   describe('checkCSPForWorkerSrc', () => {
     it('Should be invalid if no worker-src', () => {
-      expect(
-        checkCSPForWorkerSrc(
-          [
-            `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
-              `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';`,
-          ],
-          ORIGIN_TYPE.FACEBOOK,
-        ),
-      ).toBeFalsy();
+      const [isValid] = checkCSPForWorkerSrc(
+        [
+          `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
+            `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';`,
+        ],
+        ORIGIN_TYPE.FACEBOOK,
+      );
+      expect(isValid).toBeFalsy();
     });
     it('Should be invalid if we have a valid worker-src', () => {
-      expect(
-        checkCSPForWorkerSrc(
-          [
-            `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
-              `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';` +
-              'worker-src *.facebook.com/worker_url;',
-          ],
-          ORIGIN_TYPE.FACEBOOK,
-        ),
-      ).toBeTruthy();
+      const [isValid] = checkCSPForWorkerSrc(
+        [
+          `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
+            `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';` +
+            'worker-src *.facebook.com/worker_url;',
+        ],
+        ORIGIN_TYPE.FACEBOOK,
+      );
+      expect(isValid).toBeTruthy();
     });
     it('Should be invalid if we have an invalid worker-src (domain wide url scheme)', () => {
-      expect(
-        checkCSPForWorkerSrc(
-          [
-            `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
-              `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';` +
-              'worker-src *.facebook.com;',
-          ],
-          ORIGIN_TYPE.FACEBOOK,
-        ),
-      ).toBeFalsy();
+      const [isValid] = checkCSPForWorkerSrc(
+        [
+          `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
+            `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';` +
+            'worker-src *.facebook.com;',
+        ],
+        ORIGIN_TYPE.FACEBOOK,
+      );
+      expect(isValid).toBeFalsy();
     });
     it('Should be valid if we have valid worker-src (different origin domain wide url scheme)', () => {
-      expect(
-        checkCSPForWorkerSrc(
-          [
-            `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
-              `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';` +
-              'worker-src *.facebook.com/;',
-          ],
-          ORIGIN_TYPE.INSTAGRAM,
-        ),
-      ).toBeTruthy();
+      const [isValid] = checkCSPForWorkerSrc(
+        [
+          `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
+            `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';` +
+            'worker-src *.facebook.com/;',
+        ],
+        ORIGIN_TYPE.INSTAGRAM,
+      );
+      expect(isValid).toBeTruthy();
     });
     it('Should be invalid if we have an invalid worker-src (domain wide url scheme)', () => {
-      expect(
-        checkCSPForWorkerSrc(
-          [
-            `default-src data: blob: 'self' *.instagram.com *.fbcdn.net 'wasm-unsafe-eval';` +
-              `script-src *.instagram.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';` +
-              'worker-src *.instagram.com/;',
-          ],
-          ORIGIN_TYPE.INSTAGRAM,
-        ),
-      ).toBeFalsy();
+      const [isValid] = checkCSPForWorkerSrc(
+        [
+          `default-src data: blob: 'self' *.instagram.com *.fbcdn.net 'wasm-unsafe-eval';` +
+            `script-src *.instagram.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';` +
+            'worker-src *.instagram.com/;',
+        ],
+        ORIGIN_TYPE.INSTAGRAM,
+      );
+      expect(isValid).toBeFalsy();
     });
     it('Should be invalid if we have an invalid worker-src (data:)', () => {
-      expect(
-        checkCSPForWorkerSrc(
-          [
-            `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
-              `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';` +
-              'worker-src data:',
-          ],
-          ORIGIN_TYPE.FACEBOOK,
-        ),
-      ).toBeFalsy();
+      const [isValid] = checkCSPForWorkerSrc(
+        [
+          `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
+            `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';` +
+            'worker-src data:',
+        ],
+        ORIGIN_TYPE.FACEBOOK,
+      );
+      expect(isValid).toBeFalsy();
     });
     it('Should be invalid if we have an invalid worker-src (blob:)', () => {
-      expect(
-        checkCSPForWorkerSrc(
-          [
-            `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
-              `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';` +
-              'worker-src blob:',
-          ],
-          ORIGIN_TYPE.FACEBOOK,
-        ),
-      ).toBeFalsy();
+      const [isValid] = checkCSPForWorkerSrc(
+        [
+          `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
+            `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';` +
+            'worker-src blob:',
+        ],
+        ORIGIN_TYPE.FACEBOOK,
+      );
+      expect(isValid).toBeFalsy();
     });
     it('Should be invalid if we have a mix of valid and invalid source values', () => {
-      expect(
-        checkCSPForWorkerSrc(
-          [
-            `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
-              `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';` +
-              'worker-src blob: facebook.com/worker_url;',
-          ],
-          ORIGIN_TYPE.FACEBOOK,
-        ),
-      ).toBeFalsy();
+      const [isValid] = checkCSPForWorkerSrc(
+        [
+          `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
+            `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';` +
+            'worker-src blob: facebook.com/worker_url;',
+        ],
+        ORIGIN_TYPE.FACEBOOK,
+      );
+      expect(isValid).toBeFalsy();
     });
   });
 });

--- a/src/js/contentUtils.ts
+++ b/src/js/contentUtils.ts
@@ -562,14 +562,13 @@ export function startFor(origin: Origin, config: ContentScriptConfig): void {
             'Expected CSP Headers in CONTENT_SCRIPT_START response',
           );
         }
-        const validCSP = checkDocumentCSPHeaders(
+        checkDocumentCSPHeaders(
           resp.cspHeaders,
           resp.cspReportHeaders,
           getCurrentOrigin(),
         );
-        if (validCSP) {
-          allowedWorkerCSPs = getAllowedWorkerCSPs(resp.cspHeaders);
-        }
+
+        allowedWorkerCSPs = getAllowedWorkerCSPs(resp.cspHeaders);
       }
     },
   );


### PR DESCRIPTION
Changes:
- For all our CSP checks, adds a "reason" field as the return when validation fails. This allows us to simplify handling in a single place.
- Update the handling of these error to use `invalidateAndThrow` to avoid strange side-effects after invalidation.
- Make the two top level checker functions (`checkDocumentCSPHeaders`, `checkWorkerEndpointCSP`) return void to better reflect how they actually behave (either they succeed or they throw, no need for a return).

Note: the tests have not materially changed, they've just been reformatted to reflect the return being a tuple.