### PR TITLE
Revert checks back to not throwing

### DIFF
--- a/src/js/__tests__/checkDocumentCSPHeaders-test.js
+++ b/src/js/__tests__/checkDocumentCSPHeaders-test.js
@@ -42,29 +42,27 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeTruthy();
     });
     it('Enforce invalid due to script-src, missing Report policy', () => {
-      expect(() =>
-        checkDocumentCSPHeaders(
-          [
-            `default-src data: blob: 'self' *.facebook.com *.fbcdn.net;` +
-              `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';` +
-              'worker-src *.facebook.com/worker_url;',
-          ],
-          [],
-          ORIGIN_TYPE.FACEBOOK,
-        ),
-      ).toThrow(new Error('Missing CSP report-only header'));
+      const isValid = checkDocumentCSPHeaders(
+        [
+          `default-src data: blob: 'self' *.facebook.com *.fbcdn.net;` +
+            `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';` +
+            'worker-src *.facebook.com/worker_url;',
+        ],
+        [],
+        ORIGIN_TYPE.FACEBOOK,
+      );
+      expect(isValid).toBeFalsy();
     });
     it('Enforce invalid due to default-src, missing Report policy', () => {
-      expect(() =>
-        checkDocumentCSPHeaders(
-          [
-            `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'unsafe-eval';` +
-              'worker-src *.facebook.com/worker_url;',
-          ],
-          [],
-          ORIGIN_TYPE.FACEBOOK,
-        ),
-      ).toThrow(new Error('Missing CSP report-only header'));
+      const isValid = checkDocumentCSPHeaders(
+        [
+          `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'unsafe-eval';` +
+            'worker-src *.facebook.com/worker_url;',
+        ],
+        [],
+        ORIGIN_TYPE.FACEBOOK,
+      );
+      expect(isValid).toBeFalsy();
     });
   });
   describe('Report affecting outcome', () => {
@@ -88,27 +86,25 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeTruthy();
     });
     it('Enforce invalid, incorrect Report policy because of script-src', () => {
-      expect(() =>
-        checkDocumentCSPHeaders(
-          ['worker-src *.facebook.com/worker_url;'],
-          [
-            `default-src data: blob: 'self' *.facebook.com *.fbcdn.net;` +
-              `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
-          ],
-          ORIGIN_TYPE.FACEBOOK,
-        ),
-      ).toThrow(new Error('Missing unsafe-eval from CSP report-only header'));
+      const isValid = checkDocumentCSPHeaders(
+        ['worker-src *.facebook.com/worker_url;'],
+        [
+          `default-src data: blob: 'self' *.facebook.com *.fbcdn.net;` +
+            `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
+        ],
+        ORIGIN_TYPE.FACEBOOK,
+      );
+      expect(isValid).toBeFalsy();
     });
     it('Enforce invalid, incorrect Report policy because of default-src', () => {
-      expect(() =>
-        checkDocumentCSPHeaders(
-          ['worker-src *.facebook.com/worker_url;'],
-          [
-            `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'unsafe-eval';`,
-          ],
-          ORIGIN_TYPE.FACEBOOK,
-        ),
-      ).toThrow(new Error('Missing unsafe-eval from CSP report-only header'));
+      const isValid = checkDocumentCSPHeaders(
+        ['worker-src *.facebook.com/worker_url;'],
+        [
+          `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'unsafe-eval';`,
+        ],
+        ORIGIN_TYPE.FACEBOOK,
+      );
+      expect(isValid).toBeFalsy();
     });
   });
   describe('Multiple policies, enforcement', () => {
@@ -173,29 +169,27 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeTruthy();
     });
     it('Should be invalid if policy with precedence is not enforcing, script-src precedence', () => {
-      expect(() =>
-        checkDocumentCSPHeaders(
-          [
-            `default-src *.facebook.com;`,
-            `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
-          ],
-          [],
-          ORIGIN_TYPE.FACEBOOK,
-        ),
-      ).toThrow(new Error('Missing CSP report-only header'));
+      const isValid = checkDocumentCSPHeaders(
+        [
+          `default-src *.facebook.com;`,
+          `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
+        ],
+        [],
+        ORIGIN_TYPE.FACEBOOK,
+      );
+      expect(isValid).toBeFalsy();
     });
     it('Should be invalid if none of the policies are enforcing, script-src precedence', () => {
-      expect(() =>
-        checkDocumentCSPHeaders(
-          [
-            `default-src *.facebook.com;` +
-              `script-src *.facebook.com 'unsafe-eval';`,
-            `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
-          ],
-          [],
-          ORIGIN_TYPE.FACEBOOK,
-        ),
-      ).toThrow(new Error('Missing CSP report-only header'));
+      const isValid = checkDocumentCSPHeaders(
+        [
+          `default-src *.facebook.com;` +
+            `script-src *.facebook.com 'unsafe-eval';`,
+          `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
+        ],
+        [],
+        ORIGIN_TYPE.FACEBOOK,
+      );
+      expect(isValid).toBeFalsy();
     });
     it('Should be invalid if valid policies but missing worker-src', () => {
       const isValid = checkDocumentCSPHeaders(
@@ -260,29 +254,27 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeTruthy();
     });
     it('Should be invalid if policy with precedence is not reporting, script-src precedence', () => {
-      expect(() =>
-        checkDocumentCSPHeaders(
-          [],
-          [
-            `default-src *.facebook.com;`,
-            `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
-          ],
-          ORIGIN_TYPE.FACEBOOK,
-        ),
-      ).toThrow(new Error('Missing unsafe-eval from CSP report-only header'));
+      const isValid = checkDocumentCSPHeaders(
+        [],
+        [
+          `default-src *.facebook.com;`,
+          `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
+        ],
+        ORIGIN_TYPE.FACEBOOK,
+      );
+      expect(isValid).toBeFalsy();
     });
     it('Should be invalid if none of the policies are reporting, script-src precedence', () => {
-      expect(() =>
-        checkDocumentCSPHeaders(
-          [],
-          [
-            `default-src *.facebook.com;` +
-              `script-src *.facebook.com 'unsafe-eval';`,
-            `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
-          ],
-          ORIGIN_TYPE.FACEBOOK,
-        ),
-      ).toThrow(new Error('Missing unsafe-eval from CSP report-only header'));
+      const isValid = checkDocumentCSPHeaders(
+        [],
+        [
+          `default-src *.facebook.com;` +
+            `script-src *.facebook.com 'unsafe-eval';`,
+          `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
+        ],
+        ORIGIN_TYPE.FACEBOOK,
+      );
+      expect(isValid).toBeFalsy();
     });
   });
   describe('Worker CSP', () => {

--- a/src/js/__tests__/checkWorkerEndpointCSP-test.js
+++ b/src/js/__tests__/checkWorkerEndpointCSP-test.js
@@ -21,7 +21,7 @@ describe('checkWorkerEndpointCSP', () => {
     setCurrentOrigin('FACEBOOK');
   });
   it('Invalid if no CSP headers on Worker script', () => {
-    expect(() =>
+    expect(
       checkWorkerEndpointCSP(
         {
           responseHeaders: [],
@@ -29,10 +29,10 @@ describe('checkWorkerEndpointCSP', () => {
         [new Set()],
         ORIGIN_TYPE.FACEBOOK,
       ),
-    ).toThrow(new Error('Missing CSP report-only header'));
+    ).toBeFalsy();
   });
   it('Invalid if empty CSP headers on Worker script', () => {
-    expect(() =>
+    expect(
       checkWorkerEndpointCSP(
         {
           responseHeaders: [
@@ -43,14 +43,14 @@ describe('checkWorkerEndpointCSP', () => {
         [new Set()],
         ORIGIN_TYPE.FACEBOOK,
       ),
-    ).toThrow(new Error('Missing CSP report-only header'));
+    ).toBeFalsy();
   });
   /**
    * Evals covered more extensively by checkDocumentCSPHeaders
    * Same logic is used for both CSPs
    */
   it('Invalid if eval allowed by CSP', () => {
-    expect(() =>
+    expect(
       checkWorkerEndpointCSP(
         {
           responseHeaders: [
@@ -67,7 +67,7 @@ describe('checkWorkerEndpointCSP', () => {
         [new Set(['*.facebook.com/worker_url'])],
         ORIGIN_TYPE.FACEBOOK,
       ),
-    ).toThrow(new Error('Missing CSP report-only header'));
+    ).toBeFalsy();
   });
   it('Invalid if blob: allowed by script src', () => {
     expect(


### PR DESCRIPTION
This resets the behavior of the CSP checks back to how they were before #268. I will re-introduce this `invalidateAndThrow` behavior in a later PR, but reverting this now makes it easier to see what is going on.

In following PRs I intend to
- Refactor the tests for this code so as to be more granular. Right now we are running tests at the `checkDocumentCSPHeaders` level, but as we add more individual checks (e.g. for unsafe-inline) this will start to make it unclear which rule an individual test is for.
- Re-introduce the `invalidateAndThrow`, but at the `checkDocumentCSPHeaders` level. This will allow the individual checks (checkCSPForEvals, checkCSPForWorkerSrc) to be flexibly used as checks, and more easily tested, while still retaining the invalidate/throw behavior.
- Add a `checkCSPForUnsafeInline` method.