### PR TITLE
Remove unnecessary stringify in bg logging

### DIFF
--- a/src/js/background.ts
+++ b/src/js/background.ts
@@ -74,7 +74,7 @@ function logReceivedMessage(
       break;
   }
   if (sender.tab) {
-    logger(`handleMessages from tab:${sender.tab.id}`, JSON.stringify(message));
+    logger(`handleMessages from tab:${sender.tab.id}`, message);
   } else {
     logger(`handleMessages from unknown tab`, message);
   }


### PR DESCRIPTION
This made it harder to dig into object logged by the bg/service-worker.

