### PR TITLE
Make document CSP check tests more granular

### DIFF
--- a/src/js/__tests__/checkDocumentCSPHeaders-test.js
+++ b/src/js/__tests__/checkDocumentCSPHeaders-test.js
@@ -8,7 +8,8 @@
 'use strict';
 
 import {jest} from '@jest/globals';
-import {checkDocumentCSPHeaders} from '../content/checkDocumentCSPHeaders';
+import {checkCSPForWorkerSrc} from '../content/checkDocumentCSPHeaders';
+import {checkCSPForEvals} from '../content/checkCSPForEvals';
 import {ORIGIN_TYPE} from '../config';
 import {setCurrentOrigin} from '../content/updateCurrentState';
 
@@ -19,11 +20,10 @@ describe('checkDocumentCSPHeaders', () => {
   });
   describe('Enforce precedence', () => {
     it('Enforce valid policy from script-src', () => {
-      const isValid = checkDocumentCSPHeaders(
+      const isValid = checkCSPForEvals(
         [
           `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
-            `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';` +
-            'worker-src *.facebook.com/worker_url;',
+            `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';`,
         ],
         [],
         ORIGIN_TYPE.FACEBOOK,
@@ -31,10 +31,9 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeTruthy();
     });
     it('Enforce valid policy from default-src', () => {
-      const isValid = checkDocumentCSPHeaders(
+      const isValid = checkCSPForEvals(
         [
-          `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
-            'worker-src *.facebook.com/worker_url;',
+          `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';`,
         ],
         [],
         ORIGIN_TYPE.FACEBOOK,
@@ -42,11 +41,10 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeTruthy();
     });
     it('Enforce invalid due to script-src, missing Report policy', () => {
-      const isValid = checkDocumentCSPHeaders(
+      const isValid = checkCSPForEvals(
         [
           `default-src data: blob: 'self' *.facebook.com *.fbcdn.net;` +
-            `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';` +
-            'worker-src *.facebook.com/worker_url;',
+            `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
         ],
         [],
         ORIGIN_TYPE.FACEBOOK,
@@ -54,10 +52,9 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeFalsy();
     });
     it('Enforce invalid due to default-src, missing Report policy', () => {
-      const isValid = checkDocumentCSPHeaders(
+      const isValid = checkCSPForEvals(
         [
-          `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'unsafe-eval';` +
-            'worker-src *.facebook.com/worker_url;',
+          `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'unsafe-eval';`,
         ],
         [],
         ORIGIN_TYPE.FACEBOOK,
@@ -67,8 +64,8 @@ describe('checkDocumentCSPHeaders', () => {
   });
   describe('Report affecting outcome', () => {
     it('Enforce invalid, correct Report policy because of script-src', () => {
-      const isValid = checkDocumentCSPHeaders(
-        ['worker-src *.facebook.com/worker_url;'],
+      const isValid = checkCSPForEvals(
+        [],
         [
           `default-src data: blob: 'self' *.facebook.com *.fbcdn.net;` +
             `script-src *.facebook.com *.fbcdn.net blob: data: 'self';`,
@@ -78,16 +75,16 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeTruthy();
     });
     it('Enforce invalid, correct Report policy because of default-src', () => {
-      const isValid = checkDocumentCSPHeaders(
-        ['worker-src *.facebook.com/worker_url;'],
+      const isValid = checkCSPForEvals(
+        [],
         [`default-src data: blob: 'self' *.facebook.com *.fbcdn.net;`],
         ORIGIN_TYPE.FACEBOOK,
       );
       expect(isValid).toBeTruthy();
     });
     it('Enforce invalid, incorrect Report policy because of script-src', () => {
-      const isValid = checkDocumentCSPHeaders(
-        ['worker-src *.facebook.com/worker_url;'],
+      const isValid = checkCSPForEvals(
+        [],
         [
           `default-src data: blob: 'self' *.facebook.com *.fbcdn.net;` +
             `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
@@ -97,8 +94,8 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeFalsy();
     });
     it('Enforce invalid, incorrect Report policy because of default-src', () => {
-      const isValid = checkDocumentCSPHeaders(
-        ['worker-src *.facebook.com/worker_url;'],
+      const isValid = checkCSPForEvals(
+        [],
         [
           `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'unsafe-eval';`,
         ],
@@ -109,7 +106,7 @@ describe('checkDocumentCSPHeaders', () => {
   });
   describe('Multiple policies, enforcement', () => {
     it('Should be valid if one of the policies is enforcing, both script-src', () => {
-      const isValid = checkDocumentCSPHeaders(
+      const isValid = checkCSPForEvals(
         [
           `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';` +
             'worker-src *.facebook.com/worker_url;',
@@ -121,7 +118,7 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeTruthy();
     });
     it('Should be valid if one of the policies is enforcing, both default-src', () => {
-      const isValid = checkDocumentCSPHeaders(
+      const isValid = checkCSPForEvals(
         [
           `default-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';` +
             'worker-src *.facebook.com/worker_url;',
@@ -133,7 +130,7 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeTruthy();
     });
     it('Should be valid if one of the policies is enforcing, script-src precedence', () => {
-      const isValid = checkDocumentCSPHeaders(
+      const isValid = checkCSPForEvals(
         [
           `default-src 'unsafe-eval';` +
             'worker-src *.facebook.com/worker_url;',
@@ -145,11 +142,10 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeTruthy();
     });
     it('Should be valid if one of the policies is enforcing, script-src precedence', () => {
-      const isValid = checkDocumentCSPHeaders(
+      const isValid = checkCSPForEvals(
         [
           ``,
-          `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';` +
-            'worker-src *.facebook.com/worker_url;',
+          `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';`,
         ],
         [],
         ORIGIN_TYPE.FACEBOOK,
@@ -157,11 +153,10 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeTruthy();
     });
     it('Should be valid if one of the policies is enforcing, default-src precedence', () => {
-      const isValid = checkDocumentCSPHeaders(
+      const isValid = checkCSPForEvals(
         [
           ``,
-          `default-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';` +
-            'worker-src *.facebook.com/worker_url;',
+          `default-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';`,
         ],
         [],
         ORIGIN_TYPE.FACEBOOK,
@@ -169,7 +164,7 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeTruthy();
     });
     it('Should be invalid if policy with precedence is not enforcing, script-src precedence', () => {
-      const isValid = checkDocumentCSPHeaders(
+      const isValid = checkCSPForEvals(
         [
           `default-src *.facebook.com;`,
           `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
@@ -180,7 +175,7 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeFalsy();
     });
     it('Should be invalid if none of the policies are enforcing, script-src precedence', () => {
-      const isValid = checkDocumentCSPHeaders(
+      const isValid = checkCSPForEvals(
         [
           `default-src *.facebook.com;` +
             `script-src *.facebook.com 'unsafe-eval';`,
@@ -191,22 +186,11 @@ describe('checkDocumentCSPHeaders', () => {
       );
       expect(isValid).toBeFalsy();
     });
-    it('Should be invalid if valid policies but missing worker-src', () => {
-      const isValid = checkDocumentCSPHeaders(
-        [
-          `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';`,
-          `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';`,
-        ],
-        [],
-        ORIGIN_TYPE.FACEBOOK,
-      );
-      expect(isValid).toBeFalsy();
-    });
   });
   describe('Multiple policies, report-only', () => {
     it('Should be valid if one of the policies is reporting, both script-src', () => {
-      const isValid = checkDocumentCSPHeaders(
-        ['worker-src *.facebook.com/worker_url;'],
+      const isValid = checkCSPForEvals(
+        [],
         [
           `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
           `script-src *.facebook.com *.fbcdn.net blob: data: 'self';`,
@@ -216,8 +200,8 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeTruthy();
     });
     it('Should be valid if one of the policies is reporting, both default-src', () => {
-      const isValid = checkDocumentCSPHeaders(
-        ['worker-src *.facebook.com/worker_url;'],
+      const isValid = checkCSPForEvals(
+        [],
         [
           `default-src *.facebook.com *.fbcdn.net blob: data: 'self' 'unsafe-eval';`,
           `default-src *.facebook.com *.fbcdn.net blob: data: 'self';`,
@@ -227,8 +211,8 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeTruthy();
     });
     it('Should be valid if one of the policies is reporting, script-src precedence', () => {
-      const isValid = checkDocumentCSPHeaders(
-        ['worker-src *.facebook.com/worker_url;'],
+      const isValid = checkCSPForEvals(
+        [],
         [
           `default-src 'unsafe-eval';`,
           `script-src *.facebook.com *.fbcdn.net blob: data: 'self';`,
@@ -238,23 +222,23 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeTruthy();
     });
     it('Should be valid if one of the policies is reporting, script-src precedence', () => {
-      const isValid = checkDocumentCSPHeaders(
-        ['worker-src *.facebook.com/worker_url;'],
+      const isValid = checkCSPForEvals(
+        [],
         [``, `script-src *.facebook.com *.fbcdn.net blob: data: 'self';`],
         ORIGIN_TYPE.FACEBOOK,
       );
       expect(isValid).toBeTruthy();
     });
     it('Should be valid if one of the policies is reporting, default-src precedence', () => {
-      const isValid = checkDocumentCSPHeaders(
-        ['worker-src *.facebook.com/worker_url;'],
+      const isValid = checkCSPForEvals(
+        [],
         [``, `default-src *.facebook.com *.fbcdn.net blob: data: 'self';`],
         ORIGIN_TYPE.FACEBOOK,
       );
       expect(isValid).toBeTruthy();
     });
     it('Should be invalid if policy with precedence is not reporting, script-src precedence', () => {
-      const isValid = checkDocumentCSPHeaders(
+      const isValid = checkCSPForEvals(
         [],
         [
           `default-src *.facebook.com;`,
@@ -265,7 +249,7 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeFalsy();
     });
     it('Should be invalid if none of the policies are reporting, script-src precedence', () => {
-      const isValid = checkDocumentCSPHeaders(
+      const isValid = checkCSPForEvals(
         [],
         [
           `default-src *.facebook.com;` +
@@ -277,106 +261,98 @@ describe('checkDocumentCSPHeaders', () => {
       expect(isValid).toBeFalsy();
     });
   });
-  describe('Worker CSP', () => {
+  describe('checkCSPForWorkerSrc', () => {
     it('Should be invalid if no worker-src', () => {
       expect(
-        checkDocumentCSPHeaders(
+        checkCSPForWorkerSrc(
           [
             `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
               `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';`,
           ],
-          [],
           ORIGIN_TYPE.FACEBOOK,
         ),
       ).toBeFalsy();
     });
     it('Should be invalid if we have a valid worker-src', () => {
       expect(
-        checkDocumentCSPHeaders(
+        checkCSPForWorkerSrc(
           [
             `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
               `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';` +
               'worker-src *.facebook.com/worker_url;',
           ],
-          [],
           ORIGIN_TYPE.FACEBOOK,
         ),
       ).toBeTruthy();
     });
     it('Should be invalid if we have an invalid worker-src (domain wide url scheme)', () => {
       expect(
-        checkDocumentCSPHeaders(
+        checkCSPForWorkerSrc(
           [
             `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
               `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';` +
               'worker-src *.facebook.com;',
           ],
-          [],
           ORIGIN_TYPE.FACEBOOK,
         ),
       ).toBeFalsy();
     });
     it('Should be valid if we have valid worker-src (different origin domain wide url scheme)', () => {
       expect(
-        checkDocumentCSPHeaders(
+        checkCSPForWorkerSrc(
           [
             `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
               `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';` +
               'worker-src *.facebook.com/;',
           ],
-          [],
           ORIGIN_TYPE.INSTAGRAM,
         ),
       ).toBeTruthy();
     });
     it('Should be invalid if we have an invalid worker-src (domain wide url scheme)', () => {
       expect(
-        checkDocumentCSPHeaders(
+        checkCSPForWorkerSrc(
           [
             `default-src data: blob: 'self' *.instagram.com *.fbcdn.net 'wasm-unsafe-eval';` +
               `script-src *.instagram.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';` +
               'worker-src *.instagram.com/;',
           ],
-          [],
           ORIGIN_TYPE.INSTAGRAM,
         ),
       ).toBeFalsy();
     });
     it('Should be invalid if we have an invalid worker-src (data:)', () => {
       expect(
-        checkDocumentCSPHeaders(
+        checkCSPForWorkerSrc(
           [
             `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
               `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';` +
               'worker-src data:',
           ],
-          [],
           ORIGIN_TYPE.FACEBOOK,
         ),
       ).toBeFalsy();
     });
     it('Should be invalid if we have an invalid worker-src (blob:)', () => {
       expect(
-        checkDocumentCSPHeaders(
+        checkCSPForWorkerSrc(
           [
             `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
               `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';` +
               'worker-src blob:',
           ],
-          [],
           ORIGIN_TYPE.FACEBOOK,
         ),
       ).toBeFalsy();
     });
     it('Should be invalid if we have a mix of valid and invalid source values', () => {
       expect(
-        checkDocumentCSPHeaders(
+        checkCSPForWorkerSrc(
           [
             `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
               `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-unsafe-eval';` +
               'worker-src blob: facebook.com/worker_url;',
           ],
-          [],
           ORIGIN_TYPE.FACEBOOK,
         ),
       ).toBeFalsy();

--- a/src/js/content/checkDocumentCSPHeaders.ts
+++ b/src/js/content/checkDocumentCSPHeaders.ts
@@ -10,7 +10,7 @@ import {updateCurrentState} from './updateCurrentState';
 import {parseCSPString} from './parseCSPString';
 import {checkCSPForEvals} from './checkCSPForEvals';
 
-function checkCSPForWorkerSrc(
+export function checkCSPForWorkerSrc(
   cspHeaders: Array<string>,
   origin: Origin,
 ): boolean {


### PR DESCRIPTION
Refactor the tests for this code so as to be more granular. Right now we are running tests at the checkDocumentCSPHeaders level, but as we add more individual checks (e.g. for unsafe-inline) this will start to make it unclear which rule an individual test is for.