### PR TITLE
Ignore .yarnrc.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist/*
 node_modules
 .DS_Store
 .yarn/
+.yarnrc.yml


### PR DESCRIPTION
Newer versions of yarn use `.yarnrc.yml` instead of `.yarnrc`. Accidentally committing this file can break the build in CD, so I recommend we ignore it for now.