### PR TITLE
Refactor checkWorkerEndpointCSP

### DIFF
--- a/src/js/__tests__/checkWorkerEndpointCSP-test.js
+++ b/src/js/__tests__/checkWorkerEndpointCSP-test.js
@@ -8,7 +8,7 @@
 'use strict';
 
 import {jest} from '@jest/globals';
-import {checkWorkerEndpointCSP} from '../content/checkWorkerEndpointCSP';
+import {isWorkerEndpointCSPValid} from '../content/checkWorkerEndpointCSP';
 import {ORIGIN_TYPE} from '../config';
 import {setCurrentOrigin} from '../content/updateCurrentState';
 
@@ -21,250 +21,237 @@ describe('checkWorkerEndpointCSP', () => {
     setCurrentOrigin('FACEBOOK');
   });
   it('Invalid if no CSP headers on Worker script', () => {
-    expect(
-      checkWorkerEndpointCSP(
-        {
-          responseHeaders: [],
-        }, // Missing headers
-        [new Set()],
-        ORIGIN_TYPE.FACEBOOK,
-      ),
-    ).toBeFalsy();
+    const [valid] = isWorkerEndpointCSPValid(
+      {
+        responseHeaders: [],
+      }, // Missing headers
+      [new Set()],
+      ORIGIN_TYPE.FACEBOOK,
+    );
+    expect(valid).toBeFalsy();
   });
   it('Invalid if empty CSP headers on Worker script', () => {
-    expect(
-      checkWorkerEndpointCSP(
-        {
-          responseHeaders: [
-            {name: CSP_KEY, value: ''},
-            {name: CSPRO_KEY, value: ''},
-          ],
-        },
-        [new Set()],
-        ORIGIN_TYPE.FACEBOOK,
-      ),
-    ).toBeFalsy();
+    const [valid] = isWorkerEndpointCSPValid(
+      {
+        responseHeaders: [
+          {name: CSP_KEY, value: ''},
+          {name: CSPRO_KEY, value: ''},
+        ],
+      },
+      [new Set()],
+      ORIGIN_TYPE.FACEBOOK,
+    );
+    expect(valid).toBeFalsy();
   });
   /**
    * Evals covered more extensively by checkDocumentCSPHeaders
    * Same logic is used for both CSPs
    */
   it('Invalid if eval allowed by CSP', () => {
-    expect(
-      checkWorkerEndpointCSP(
-        {
-          responseHeaders: [
-            {
-              name: CSP_KEY,
-              value:
-                `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
-                `script-src *.facebook.com *.fbcdn.net 'self' 'unsafe-eval';` +
-                'worker-src *.facebook.com/worker_url;',
-            },
-            {name: CSPRO_KEY, value: ''},
-          ],
-        },
-        [new Set(['*.facebook.com/worker_url'])],
-        ORIGIN_TYPE.FACEBOOK,
-      ),
-    ).toBeFalsy();
+    const [valid] = isWorkerEndpointCSPValid(
+      {
+        responseHeaders: [
+          {
+            name: CSP_KEY,
+            value:
+              `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
+              `script-src *.facebook.com *.fbcdn.net 'self' 'unsafe-eval';` +
+              'worker-src *.facebook.com/worker_url;',
+          },
+          {name: CSPRO_KEY, value: ''},
+        ],
+      },
+      [new Set(['*.facebook.com/worker_url'])],
+      ORIGIN_TYPE.FACEBOOK,
+    );
+    expect(valid).toBeFalsy();
   });
   it('Invalid if blob: allowed by script src', () => {
-    expect(
-      checkWorkerEndpointCSP(
-        {
-          responseHeaders: [
-            {
-              name: CSP_KEY,
-              value:
-                `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
-                `script-src *.facebook.com *.fbcdn.net 'self' blob: 'wasm-unsafe-eval';` +
-                'worker-src *.facebook.com/worker_url;',
-            },
-            {name: CSPRO_KEY, value: ''},
-          ],
-        },
-        [new Set(['*.facebook.com/worker_url'])],
-        ORIGIN_TYPE.FACEBOOK,
-      ),
-    ).toBeFalsy();
+    const [valid] = isWorkerEndpointCSPValid(
+      {
+        responseHeaders: [
+          {
+            name: CSP_KEY,
+            value:
+              `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
+              `script-src *.facebook.com *.fbcdn.net 'self' blob: 'wasm-unsafe-eval';` +
+              'worker-src *.facebook.com/worker_url;',
+          },
+          {name: CSPRO_KEY, value: ''},
+        ],
+      },
+      [new Set(['*.facebook.com/worker_url'])],
+      ORIGIN_TYPE.FACEBOOK,
+    );
+    expect(valid).toBeFalsy();
   });
   it('Invalid if data: allowed by script src', () => {
-    expect(
-      checkWorkerEndpointCSP(
-        {
-          responseHeaders: [
-            {
-              name: CSP_KEY,
-              value:
-                `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
-                `script-src *.facebook.com *.fbcdn.net 'self' data: 'wasm-unsafe-eval';` +
-                'worker-src *.facebook.com/worker_url;',
-            },
-            {name: CSPRO_KEY, value: ''},
-          ],
-        },
-        [new Set(['*.facebook.com/worker_url'])],
-        ORIGIN_TYPE.FACEBOOK,
-      ),
-    ).toBeFalsy();
+    const [valid] = isWorkerEndpointCSPValid(
+      {
+        responseHeaders: [
+          {
+            name: CSP_KEY,
+            value:
+              `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
+              `script-src *.facebook.com *.fbcdn.net 'self' data: 'wasm-unsafe-eval';` +
+              'worker-src *.facebook.com/worker_url;',
+          },
+          {name: CSPRO_KEY, value: ''},
+        ],
+      },
+      [new Set(['*.facebook.com/worker_url'])],
+      ORIGIN_TYPE.FACEBOOK,
+    );
+    expect(valid).toBeFalsy();
   });
   it('Invalid if blob: allowed by default src', () => {
-    expect(
-      checkWorkerEndpointCSP(
-        {
-          responseHeaders: [
-            {
-              name: CSP_KEY,
-              value:
-                `default-src blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
-                'worker-src *.facebook.com/worker_url;',
-            },
-            {name: CSPRO_KEY, value: ''},
-          ],
-        },
-        [new Set(['*.facebook.com/worker_url'])],
-        ORIGIN_TYPE.FACEBOOK,
-      ),
-    ).toBeFalsy();
+    const [valid] = isWorkerEndpointCSPValid(
+      {
+        responseHeaders: [
+          {
+            name: CSP_KEY,
+            value:
+              `default-src blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
+              'worker-src *.facebook.com/worker_url;',
+          },
+          {name: CSPRO_KEY, value: ''},
+        ],
+      },
+      [new Set(['*.facebook.com/worker_url'])],
+      ORIGIN_TYPE.FACEBOOK,
+    );
+    expect(valid).toBeFalsy();
   });
   it('Invalid if data: allowed by default src', () => {
-    expect(
-      checkWorkerEndpointCSP(
-        {
-          responseHeaders: [
-            {
-              name: CSP_KEY,
-              value:
-                `default-src data: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
-                'worker-src *.facebook.com/worker_url;',
-            },
-            {name: CSPRO_KEY, value: ''},
-          ],
-        },
-        [new Set(['*.facebook.com/worker_url'])],
-        ORIGIN_TYPE.FACEBOOK,
-      ),
-    ).toBeFalsy();
+    const [valid] = isWorkerEndpointCSPValid(
+      {
+        responseHeaders: [
+          {
+            name: CSP_KEY,
+            value:
+              `default-src data: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
+              'worker-src *.facebook.com/worker_url;',
+          },
+          {name: CSPRO_KEY, value: ''},
+        ],
+      },
+      [new Set(['*.facebook.com/worker_url'])],
+      ORIGIN_TYPE.FACEBOOK,
+    );
+    expect(valid).toBeFalsy();
   });
   it('Valid CSP, same url nested workers and different origins', () => {
-    expect(
-      checkWorkerEndpointCSP(
-        {
-          responseHeaders: [
-            {
-              name: CSP_KEY,
-              value:
-                `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
-                `script-src *.facebook.com *.fbcdn.net 'self' 'wasm-unsafe-eval';` +
-                'worker-src *.facebook.com/worker_url *.instagram.com;',
-            },
-            {name: CSPRO_KEY, value: ''},
-          ],
-        },
-        [new Set(['*.facebook.com/worker_url'])],
-        ORIGIN_TYPE.FACEBOOK,
-      ),
-    ).toBeTruthy();
+    const [valid] = isWorkerEndpointCSPValid(
+      {
+        responseHeaders: [
+          {
+            name: CSP_KEY,
+            value:
+              `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
+              `script-src *.facebook.com *.fbcdn.net 'self' 'wasm-unsafe-eval';` +
+              'worker-src *.facebook.com/worker_url *.instagram.com;',
+          },
+          {name: CSPRO_KEY, value: ''},
+        ],
+      },
+      [new Set(['*.facebook.com/worker_url'])],
+      ORIGIN_TYPE.FACEBOOK,
+    );
+    expect(valid).toBeTruthy();
   });
   it('Valid CSP, nested workers (non-exact match)', () => {
-    expect(
-      checkWorkerEndpointCSP(
-        {
-          responseHeaders: [
-            {
-              name: CSP_KEY,
-              value:
-                `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
-                `script-src *.facebook.com *.fbcdn.net 'self' 'wasm-unsafe-eval';` +
-                'worker-src *.facebook.com/worker_url/;',
-            },
-            {name: CSPRO_KEY, value: ''},
-          ],
-        },
-        [new Set(['*.facebook.com/worker_url/'])],
-        ORIGIN_TYPE.FACEBOOK,
-      ),
-    ).toBeTruthy();
+    const [valid] = isWorkerEndpointCSPValid(
+      {
+        responseHeaders: [
+          {
+            name: CSP_KEY,
+            value:
+              `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
+              `script-src *.facebook.com *.fbcdn.net 'self' 'wasm-unsafe-eval';` +
+              'worker-src *.facebook.com/worker_url/;',
+          },
+          {name: CSPRO_KEY, value: ''},
+        ],
+      },
+      [new Set(['*.facebook.com/worker_url/'])],
+      ORIGIN_TYPE.FACEBOOK,
+    );
+    expect(valid).toBeTruthy();
   });
   it('Valid CSP, subpath nested workers', () => {
-    expect(
-      checkWorkerEndpointCSP(
-        {
-          responseHeaders: [
-            {
-              name: CSP_KEY,
-              value:
-                `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
-                `script-src *.facebook.com *.fbcdn.net 'self' 'wasm-unsafe-eval';` +
-                'worker-src *.facebook.com/worker_url/first *.facebook.com/worker_url/second;',
-            },
-            {name: CSPRO_KEY, value: ''},
-          ],
-        },
-        [new Set(['*.facebook.com/worker_url/'])],
-        ORIGIN_TYPE.FACEBOOK,
-      ),
-    ).toBeTruthy();
+    const [valid] = isWorkerEndpointCSPValid(
+      {
+        responseHeaders: [
+          {
+            name: CSP_KEY,
+            value:
+              `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
+              `script-src *.facebook.com *.fbcdn.net 'self' 'wasm-unsafe-eval';` +
+              'worker-src *.facebook.com/worker_url/first *.facebook.com/worker_url/second;',
+          },
+          {name: CSPRO_KEY, value: ''},
+        ],
+      },
+      [new Set(['*.facebook.com/worker_url/'])],
+      ORIGIN_TYPE.FACEBOOK,
+    );
+    expect(valid).toBeTruthy();
   });
   it('Invalid CSP, subpath nested workers (exact match needed)', () => {
-    expect(
-      checkWorkerEndpointCSP(
-        {
-          responseHeaders: [
-            {
-              name: CSP_KEY,
-              value:
-                `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
-                `script-src *.facebook.com *.fbcdn.net 'self' 'wasm-unsafe-eval';` +
-                'worker-src *.facebook.com/worker_url/first *.facebook.com/worker_url/second;',
-            },
-            {name: CSPRO_KEY, value: ''},
-          ],
-        },
-        [new Set(['*.facebook.com/worker_url'])],
-        ORIGIN_TYPE.FACEBOOK,
-      ),
-    ).toBeFalsy();
+    const [valid] = isWorkerEndpointCSPValid(
+      {
+        responseHeaders: [
+          {
+            name: CSP_KEY,
+            value:
+              `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
+              `script-src *.facebook.com *.fbcdn.net 'self' 'wasm-unsafe-eval';` +
+              'worker-src *.facebook.com/worker_url/first *.facebook.com/worker_url/second;',
+          },
+          {name: CSPRO_KEY, value: ''},
+        ],
+      },
+      [new Set(['*.facebook.com/worker_url'])],
+      ORIGIN_TYPE.FACEBOOK,
+    );
+    expect(valid).toBeFalsy();
   });
   it('Invalid CSP, different paths', () => {
-    expect(
-      checkWorkerEndpointCSP(
-        {
-          responseHeaders: [
-            {
-              name: CSP_KEY,
-              value:
-                `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
-                `script-src *.facebook.com *.fbcdn.net 'self' 'wasm-unsafe-eval';` +
-                'worker-src *.facebook.com/wrong_worker_url *.facebook.com/worker_url;',
-            },
-            {name: CSPRO_KEY, value: ''},
-          ],
-        },
-        [new Set(['*.facebook.com/worker_url'])],
-        ORIGIN_TYPE.FACEBOOK,
-      ),
-    ).toBeFalsy();
+    const [valid] = isWorkerEndpointCSPValid(
+      {
+        responseHeaders: [
+          {
+            name: CSP_KEY,
+            value:
+              `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
+              `script-src *.facebook.com *.fbcdn.net 'self' 'wasm-unsafe-eval';` +
+              'worker-src *.facebook.com/wrong_worker_url *.facebook.com/worker_url;',
+          },
+          {name: CSPRO_KEY, value: ''},
+        ],
+      },
+      [new Set(['*.facebook.com/worker_url'])],
+      ORIGIN_TYPE.FACEBOOK,
+    );
+    expect(valid).toBeFalsy();
   });
   it('Invalid CSP, nested worker allowing domain wide urls', () => {
-    expect(
-      checkWorkerEndpointCSP(
-        {
-          responseHeaders: [
-            {
-              name: CSP_KEY,
-              value:
-                `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
-                `script-src *.facebook.com *.fbcdn.net 'self' 'wasm-unsafe-eval';` +
-                'worker-src *.facebook.com/;',
-            },
-            {name: CSPRO_KEY, value: ''},
-          ],
-        },
-        [new Set(['*.facebook.com/worker_url'])],
-        ORIGIN_TYPE.FACEBOOK,
-      ),
-    ).toBeFalsy();
+    const [valid] = isWorkerEndpointCSPValid(
+      {
+        responseHeaders: [
+          {
+            name: CSP_KEY,
+            value:
+              `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
+              `script-src *.facebook.com *.fbcdn.net 'self' 'wasm-unsafe-eval';` +
+              'worker-src *.facebook.com/;',
+          },
+          {name: CSPRO_KEY, value: ''},
+        ],
+      },
+      [new Set(['*.facebook.com/worker_url'])],
+      ORIGIN_TYPE.FACEBOOK,
+    );
+    expect(valid).toBeFalsy();
   });
 });


### PR DESCRIPTION
This PR should be a pure refactor. I'm making the follow changes:
1. Extract the bulk of `checkWorkerEndpointCSP` into a new function called `isWorkerEndpointCSPValid`. This new function should have no side-effects (no throwing, no invalidation) so that it is reusable and easier to test. `checkWorkerEndpointCSP` now calls this new function and performs any of the side-effects required.
2. The existing `checkWorkerEndpointCSP` function was performing three distinct tasks: 1) checking CSP for evals, 2) validating the worker-src, 3) Validating the absence of blob/data. (1) was already split out into a separate function, and I've done the same for (2) (`isWorkerSrcValid`) and (3) (`areBlobAndDataExcluded`). In the next PR I will make the tests for these functions more granular.
3. Updated the tests to handle a tuple return instead of a boolean. There should be no changes.