### PR TITLE
Finally kill mysterious bg error

### DIFF
--- a/src/js/background/tab_state_tracker/TabStateMachine.ts
+++ b/src/js/background/tab_state_tracker/TabStateMachine.ts
@@ -88,11 +88,23 @@ export default class TabStateMachine extends StateMachine {
       popup: `popup.html?tab_id=${this._tabId}&state=${state}&origin=${this._origin}`,
     });
     // Broadcast state update for relevant popup to update its contents.
-    sendMessageToBackground({
-      type: MESSAGE_TYPE.STATE_UPDATED,
-      tabId: this._tabId,
-      state,
-    });
+    sendMessageToBackground(
+      {
+        type: MESSAGE_TYPE.STATE_UPDATED,
+        tabId: this._tabId,
+        state,
+      },
+      () => {
+        /**
+         * The following suppresses an error that is thrown when we try to
+         * send this message to popup.js before it's listener is set up.
+         *
+         * For more details on how this suppresses the error:
+         * See: https://stackoverflow.com/questions/28431505/unchecked-runtime-lasterror-when-using-chrome-api/28432087#28432087
+         */
+        chrome.runtime.lastError && chrome.runtime.lastError.message;
+      },
+    );
     if (state === STATES.IGNORE) {
       this.genDisableTab();
     }


### PR DESCRIPTION
<img width="805" alt="image" src="https://github.com/facebookincubator/meta-code-verify/assets/20268283/13777fc1-6941-4318-be13-ec394e336f76">

This error would fire every time we try to update the popup contents even though a popup is not open. This change suppresses it from polluting the logs.