### PR TITLE
Enforce the absence of unsafe-inline on Document CSPs

### DIFF
--- a/src/js/__tests__/checkCSPForUnsafeInline-test.js
+++ b/src/js/__tests__/checkCSPForUnsafeInline-test.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import {jest} from '@jest/globals';
+import {checkCSPForUnsafeInline} from '../content/checkCSPForUnsafeInline';
+import {setCurrentOrigin} from '../content/updateCurrentState';
+
+describe('checkCSPForUnsafeInline', () => {
+  beforeEach(() => {
+    window.chrome.runtime.sendMessage = jest.fn(() => {});
+    setCurrentOrigin('FACEBOOK');
+  });
+  it('Valid due to script-src', () => {
+    const [valid] = checkCSPForUnsafeInline([
+      `default-src 'unsafe-inline';` + `script-src 'self';`,
+    ]);
+    expect(valid).toBeTruthy();
+  });
+  it('Invalid due to script-src', () => {
+    const [valid] = checkCSPForUnsafeInline([
+      `default-src 'unsafe-inline';` + `script-src 'self' 'unsafe-inline';`,
+    ]);
+    expect(valid).toBeFalsy();
+  });
+  it('Valid due to default-src', () => {
+    const [valid] = checkCSPForUnsafeInline([`default-src 'self';`]);
+    expect(valid).toBeTruthy();
+  });
+  it('Invalid due to default-src', () => {
+    const [valid] = checkCSPForUnsafeInline([
+      `default-src 'self' 'unsafe-inline';`,
+    ]);
+    expect(valid).toBeFalsy();
+  });
+});

--- a/src/js/content/checkCSPForUnsafeInline.ts
+++ b/src/js/content/checkCSPForUnsafeInline.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {parseCSPString} from './parseCSPString';
+
+/**
+ * Enforces that CSP headers do not allow unsafe-inline
+ */
+export function checkCSPForUnsafeInline(
+  cspHeaders: Array<string>,
+): [true] | [false, string] {
+  const preventsUnsafeInline = cspHeaders.some(cspHeader => {
+    const headers = parseCSPString(cspHeader);
+
+    const scriptSrc = headers.get('script-src');
+    if (scriptSrc) {
+      return !scriptSrc.has(`'unsafe-inline'`);
+    }
+
+    const defaultSrc = headers.get('default-src');
+    if (defaultSrc) {
+      return !defaultSrc.has(`'unsafe-inline'`);
+    }
+
+    return false;
+  });
+
+  if (preventsUnsafeInline) {
+    return [true];
+  } else {
+    return [false, 'CSP Headers do not prevent unsafe-inline.'];
+  }
+}

--- a/src/js/content/checkDocumentCSPHeaders.ts
+++ b/src/js/content/checkDocumentCSPHeaders.ts
@@ -9,6 +9,7 @@ import {Origin, ORIGIN_HOST} from '../config';
 import {invalidateAndThrow} from './updateCurrentState';
 import {parseCSPString} from './parseCSPString';
 import {checkCSPForEvals} from './checkCSPForEvals';
+import {checkCSPForUnsafeInline} from './checkCSPForUnsafeInline';
 
 export function checkCSPForWorkerSrc(
   cspHeaders: Array<string>,
@@ -60,6 +61,7 @@ export function checkDocumentCSPHeaders(
   origin: Origin,
 ): void {
   [
+    checkCSPForUnsafeInline(cspHeaders),
     checkCSPForEvals(cspHeaders, cspReportHeaders),
     checkCSPForWorkerSrc(cspHeaders, origin),
   ].forEach(([valid, reason]) => {

--- a/src/js/content/checkWorkerEndpointCSP.ts
+++ b/src/js/content/checkWorkerEndpointCSP.ts
@@ -89,9 +89,12 @@ export function isWorkerEndpointCSPValid(
     .map(h => h.value)
     .filter((header): header is string => !!header);
 
-  const [evalIsValid, reason] = checkCSPForEvals(cspHeaders, cspReportHeaders);
+  const [evalIsValid, evalReason] = checkCSPForEvals(
+    cspHeaders,
+    cspReportHeaders,
+  );
   if (!evalIsValid) {
-    return [false, reason];
+    return [false, evalReason];
   }
 
   if (!isWorkerSrcValid(cspHeaders, host, documentWorkerCSPs)) {


### PR DESCRIPTION
The extension will now invalidate if the documents CSP allows unsafe-inline execution.

**Testing**
- Checked on Chrome, Firefox and Edge.
- Correctly handles (green check mark) FB, MSGR and WA.
- Correctly handles Instagram, but unfortunately that means failure at the moment, because there is an extra frame loaded by IG that still has `unsafe-inline`. Submitting for review but we should hold off on merging/releasing until that issue can be addressed.