### PR TITLE
Fix content log spew

### DIFF
--- a/src/js/shared/sendMessageToBackground.ts
+++ b/src/js/shared/sendMessageToBackground.ts
@@ -11,6 +11,9 @@ export function sendMessageToBackground(
   message: MessagePayload,
   callback?: (response: MessageResponse) => void,
 ): void {
-  callback ??= () => {};
-  chrome.runtime.sendMessage(message, callback);
+  if (callback != null) {
+    chrome.runtime.sendMessage(message, callback);
+  } else {
+    chrome.runtime.sendMessage(message);
+  }
 }


### PR DESCRIPTION
We subtly changed the behavior here with the TS strictify-ing.

Chrome APIs are not happy when we send an empty callback but never call it, instead we should not send this argument. The TS definitions are poorly typed.

https://github.com/ezzak/meta-code-verify/blob/main/src/js/background.ts#L101-L105

This was causing a ton of log spew

<img width="980" alt="image" src="https://github.com/facebookincubator/meta-code-verify/assets/20268283/725decb2-68c9-448a-ae77-305559457236">
