### PR TITLE
Ensure support for mixed-case csp values/keys

### DIFF
--- a/src/js/__tests__/checkDocumentCSPHeaders-test.js
+++ b/src/js/__tests__/checkDocumentCSPHeaders-test.js
@@ -350,4 +350,28 @@ describe('checkCSPForEvals', () => {
       expect(isValid).toBeFalsy();
     });
   });
+  describe('Case insensitive CSPs', () => {
+    it('Works with mixed case CSP', () => {
+      const [isValid] = checkCSPForEvals(
+        [
+          `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
+            `sCriPt-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-UNsafe-eval';`,
+        ],
+        [],
+        ORIGIN_TYPE.FACEBOOK,
+      );
+      expect(isValid).toBeTruthy();
+    });
+    it('Blocks invalid mixed case CSP', () => {
+      const [isValid] = checkCSPForEvals(
+        [
+          `default-src data: blob: 'self' *.facebook.com *.fbcdn.net 'wasm-unsafe-eval';` +
+            `sCriPt-src *.facebook.com *.fbcdn.net blob: data: 'self' 'UNsafe-eval';`,
+        ],
+        [],
+        ORIGIN_TYPE.FACEBOOK,
+      );
+      expect(isValid).toBeFalsy();
+    });
+  });
 });

--- a/src/js/__tests__/parseFailedJSON-test.js
+++ b/src/js/__tests__/parseFailedJSON-test.js
@@ -47,7 +47,6 @@ describe('parseFailedJSON', () => {
       node.textContent = '{}';
     }, 200);
     jest.runAllTimers();
-    console.log(getFailedForTestDoNotUse());
     setTimeout(() => {
       expect(getFailedForTestDoNotUse()).toBe(null);
     }, 200);

--- a/src/js/content/parseCSPString.ts
+++ b/src/js/content/parseCSPString.ts
@@ -8,7 +8,7 @@
 export function parseCSPString(csp: string): Map<string, Set<string>> {
   const directiveStrings = csp.split(';');
   return directiveStrings.reduce((map, directiveString) => {
-    const [directive, ...values] = directiveString.split(' ');
+    const [directive, ...values] = directiveString.toLowerCase().split(' ');
     return map.set(directive, new Set(values));
   }, new Map());
 }


### PR DESCRIPTION
When we parse CSP we should make sure that we correctly check for mixed/lower/upper case directives/values