### PR TITLE
Handle CSPs with subsequent duplicate directives

### DIFF
--- a/src/js/__tests__/parseCSPString-test.js
+++ b/src/js/__tests__/parseCSPString-test.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import {parseCSPString} from '../content/parseCSPString';
+
+describe('parseCSPString', () => {
+  it('Correctly parses multiple keys/directives', () => {
+    expect(
+      parseCSPString(
+        `default-src 'self' blob:;` + `script-src 'self' 'wasm-unsafe-eval';`,
+      ),
+    ).toEqual(
+      new Map([
+        ['default-src', new Set(["'self'", 'blob:'])],
+        ['script-src', new Set(["'self'", "'wasm-unsafe-eval'"])],
+      ]),
+    );
+  });
+  it('Normalizes CSP keys/values', () => {
+    expect(
+      parseCSPString(
+        `sCriPt-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-UNsafe-eval';`,
+      ),
+    ).toEqual(
+      new Map([
+        [
+          'script-src',
+          new Set([
+            '*.facebook.com',
+            '*.fbcdn.net',
+            'blob:',
+            'data:',
+            "'self'",
+            "'wasm-unsafe-eval'",
+          ]),
+        ],
+      ]),
+    );
+  });
+  it('Ignores subsequent directive keys', () => {
+    expect(
+      parseCSPString(
+        `script-src 'none';` +
+          `script-src *.facebook.com *.fbcdn.net blob: data: 'self' 'wasm-UNsafe-eval';` +
+          `connect-src 'self';`,
+      ),
+    ).toEqual(
+      new Map([
+        ['script-src', new Set(["'none'"])],
+        ['connect-src', new Set(["'self'"])],
+      ]),
+    );
+  });
+});

--- a/src/js/content/parseCSPString.ts
+++ b/src/js/content/parseCSPString.ts
@@ -6,9 +6,13 @@
  */
 
 export function parseCSPString(csp: string): Map<string, Set<string>> {
-  const directiveStrings = csp.split(';');
+  const directiveStrings = csp.split(';').filter(Boolean);
   return directiveStrings.reduce((map, directiveString) => {
     const [directive, ...values] = directiveString.toLowerCase().split(' ');
-    return map.set(directive, new Set(values));
+    // Ignore subsequent keys for a directive, if it's specified more than once
+    if (!map.has(directive)) {
+      map.set(directive, new Set(values));
+    }
+    return map;
   }, new Map());
 }


### PR DESCRIPTION
<img width="676" alt="image" src="https://github.com/facebookincubator/meta-code-verify/assets/20268283/2f6f9e38-2bb3-4ef2-98f1-b4978da69aa7">

Browsers will ignore subsequent duplicate directives which does not match our current CSP parsing behavior where we rely on the last key/value for a directive in the string, update to match real behavior + add tests.