### PR TITLE
Correct parse CSP even when parts of it are invalid

### DIFF
--- a/src/js/__tests__/parseCSPString-test.js
+++ b/src/js/__tests__/parseCSPString-test.js
@@ -57,4 +57,14 @@ describe('parseCSPString', () => {
       ]),
     );
   });
+  it('Can still parse keys when invalid characters are present', () => {
+    expect(
+      parseCSPString(`default-src 'self';          script-src 'none';`),
+    ).toEqual(
+      new Map([
+        ['default-src', new Set(["'self'"])],
+        ['script-src', new Set(["'none'"])],
+      ]),
+    );
+  });
 });

--- a/src/js/content/parseCSPString.ts
+++ b/src/js/content/parseCSPString.ts
@@ -8,7 +8,10 @@
 export function parseCSPString(csp: string): Map<string, Set<string>> {
   const directiveStrings = csp.split(';').filter(Boolean);
   return directiveStrings.reduce((map, directiveString) => {
-    const [directive, ...values] = directiveString.toLowerCase().split(' ');
+    const [directive, ...values] = directiveString
+      .trim()
+      .toLowerCase()
+      .split(' ');
     // Ignore subsequent keys for a directive, if it's specified more than once
     if (!map.has(directive)) {
       map.set(directive, new Set(values));


### PR DESCRIPTION
![Screenshot 2023-10-30 at 3 25 41 PM](https://github.com/facebookincubator/meta-code-verify/assets/20268283/5af505f7-ef03-4978-8d94-2fa91a79fb6f)

We should continue to correctly parse other directives even when a certain expective directive (key) is invalid.
The browser behavior is to log a console error but still apply the CSPs non the less, it just complains that that the empty character(s) is an invalid key.