### PR TITLE
Handle scripts with packages from both manifests

### DIFF
--- a/src/js/shared/nestedDataHelpers.ts
+++ b/src/js/shared/nestedDataHelpers.ts
@@ -31,3 +31,16 @@ export function setOrUpdateSetInMap<OuterKey, Value>(
   }
   return outerMap;
 }
+
+export function pushToOrCreateArrayInMap<OuterKey, Value>(
+  outerMap: Map<OuterKey, Array<Value>>,
+  outerKey: OuterKey,
+  value: Value,
+): Map<OuterKey, Array<Value>> {
+  const innerArray = outerMap.get(outerKey) ?? [];
+  innerArray.push(value);
+  if (!outerMap.has(outerKey)) {
+    outerMap.set(outerKey, innerArray);
+  }
+  return outerMap;
+}


### PR DESCRIPTION
# Main change
Currently if we encounter a script that has packages in both the main and longtail manifests, something like `data-btmanifest="1009592080_main,1009592080_longtail"`, we will parse its "type" as `main,1009592080_longtail`. By virtue of the rest of the code this does actually end up working, but leaves us open to bugs introduced in future changes.

This diff updates the parsing to first check if the manifest field has both types, and if so, use "BOTH" as the type, which will ensure that this script will not be processed until both manifests have been loaded.

# Small changes
- Change `dataBtManifest == null` to `!dataBtManifest` so that we invalidate and throw if `data-btmanifest` is empty.
- While writing this code it became clear that in code path where `scriptsShouldHaveManifestProp` is true, we will **always** have a `version`, and if it is false we will **never** have a `version`, so I moved the code related to inserting into FOUND_SCRIPTS to be inside those code paths instead of separately on its own afterward. 
- Add the `pushToOrCreateArrayInMap` to clarify the operation that is happening