### PR TITLE
Add support for multiple CSPs within the same HTTP header

### DIFF
--- a/src/js/__tests__/getCSPHeadersFromWebRequestResponse-test.js
+++ b/src/js/__tests__/getCSPHeadersFromWebRequestResponse-test.js
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import {getCSPHeadersFromWebRequestResponse} from '../shared/getCSPHeadersFromWebRequestResponse';
+
+const KEY = 'Content-Security-Policy';
+
+describe('getCSPHeadersFromWebRequestResponse', () => {
+  it('Works with single header key, single value', () => {
+    expect(
+      getCSPHeadersFromWebRequestResponse({
+        responseHeaders: [
+          {name: KEY, value: 'default-src facebook.com;'},
+          {name: 'other-header', value: ''},
+        ],
+      }),
+    ).toEqual([{name: KEY, value: 'default-src facebook.com;'}]);
+  });
+  it('Works with single header key, multiple values', () => {
+    expect(
+      getCSPHeadersFromWebRequestResponse({
+        responseHeaders: [
+          {
+            name: KEY,
+            value:
+              'default-src facebook.com;, frame-ancestors https://www.facebook.com https://www.instagram.com;',
+          },
+          {name: 'other-header', value: ''},
+        ],
+      }),
+    ).toEqual([
+      {name: KEY, value: 'default-src facebook.com;'},
+      {
+        name: KEY,
+        value:
+          'frame-ancestors https://www.facebook.com https://www.instagram.com;',
+      },
+    ]);
+  });
+  it('It works with multiple header keys', () => {
+    expect(
+      getCSPHeadersFromWebRequestResponse({
+        responseHeaders: [
+          {
+            name: KEY,
+            value: 'default-src facebook.com;',
+          },
+          {
+            name: KEY,
+            value:
+              'frame-ancestors https://www.facebook.com https://www.instagram.com;',
+          },
+          {name: 'other-header', value: ''},
+        ],
+      }),
+    ).toEqual([
+      {name: KEY, value: 'default-src facebook.com;'},
+      {
+        name: KEY,
+        value:
+          'frame-ancestors https://www.facebook.com https://www.instagram.com;',
+      },
+    ]);
+  });
+  it('It works with multiple header keys, multiple values', () => {
+    expect(
+      getCSPHeadersFromWebRequestResponse({
+        responseHeaders: [
+          {
+            name: KEY,
+            value: 'script-src facebook.com;',
+          },
+          {
+            name: KEY,
+            value:
+              'default-src facebook.com;, frame-ancestors https://www.facebook.com https://www.instagram.com;',
+          },
+          {name: 'other-header', value: ''},
+        ],
+      }),
+    ).toEqual([
+      {name: KEY, value: 'script-src facebook.com;'},
+      {name: KEY, value: 'default-src facebook.com;'},
+      {
+        name: KEY,
+        value:
+          'frame-ancestors https://www.facebook.com https://www.instagram.com;',
+      },
+    ]);
+  });
+});

--- a/src/js/shared/getCSPHeadersFromWebRequestResponse.ts
+++ b/src/js/shared/getCSPHeadersFromWebRequestResponse.ts
@@ -13,11 +13,25 @@ export function getCSPHeadersFromWebRequestResponse(
   if (!responseHeaders) {
     throw new Error('Request is missing responseHeaders');
   }
-  return responseHeaders.filter(
+  const cspHeaders = responseHeaders.filter(
     header =>
       header.name.toLowerCase() ===
       (reportHeader
         ? 'content-security-policy-report-only'
         : 'content-security-policy'),
   );
+
+  // A single header value can be a comma seperated list of headers
+  // https://www.w3.org/TR/CSP3/#parse-serialized-policy-list
+  const individualHeadears: Array<chrome.webRequest.HttpHeader> = [];
+  cspHeaders.forEach(header => {
+    if (header.value?.includes(', ')) {
+      header.value.split(', ').forEach(headerValue => {
+        individualHeadears.push({name: header.name, value: headerValue});
+      });
+    } else {
+      individualHeadears.push(header);
+    }
+  });
+  return individualHeadears;
 }

--- a/src/js/shared/getCSPHeadersFromWebRequestResponse.ts
+++ b/src/js/shared/getCSPHeadersFromWebRequestResponse.ts
@@ -23,15 +23,15 @@ export function getCSPHeadersFromWebRequestResponse(
 
   // A single header value can be a comma seperated list of headers
   // https://www.w3.org/TR/CSP3/#parse-serialized-policy-list
-  const individualHeadears: Array<chrome.webRequest.HttpHeader> = [];
+  const individualHeaders: Array<chrome.webRequest.HttpHeader> = [];
   cspHeaders.forEach(header => {
     if (header.value?.includes(', ')) {
       header.value.split(', ').forEach(headerValue => {
-        individualHeadears.push({name: header.name, value: headerValue});
+        individualHeaders.push({name: header.name, value: headerValue});
       });
     } else {
-      individualHeadears.push(header);
+      individualHeaders.push(header);
     }
   });
-  return individualHeadears;
+  return individualHeaders;
 }


### PR DESCRIPTION
Turns out in some browsers, webRequest concats the two headers together, this should add support fort hat.