### PR TITLE
Tweak cloudflare endpoint permission item in manifest to allow Safari to hit it

### DIFF
--- a/config/v2/manifest.json
+++ b/config/v2/manifest.json
@@ -57,7 +57,7 @@
     ],
     "permissions": [
         "webRequest",
-        "https://*.privacy-auditability.cloudflare.com/",
+        "https://*.privacy-auditability.cloudflare.com/*",
         "https://static.xx.fbcdn.net/",
         "https://static.cdninstagram.com/",
         "*://*.messenger.com/*",


### PR DESCRIPTION
Safari does seems to treat this as an exact match

<img width="1068" alt="Screenshot 2024-01-10 at 3 36 03 PM" src="https://github.com/facebookincubator/meta-code-verify/assets/20268283/9decdac9-8460-4a21-82ae-d1a84233dcdb">

With wildcard tail
<img width="952" alt="Screenshot 2024-01-10 at 3 37 06 PM" src="https://github.com/facebookincubator/meta-code-verify/assets/20268283/21d75bc7-be40-4e14-a9b7-1c3dd415fe0e">


