### PR TITLE
Tweak v2 chrome actions for Safari

### DIFF
--- a/src/js/background/tab_state_tracker/TabStateMachine.ts
+++ b/src/js/background/tab_state_tracker/TabStateMachine.ts
@@ -23,10 +23,12 @@ function getChromeV3Action() {
     return self.chrome.action;
   } else {
     return {
-      setIcon: self.chrome.pageAction.setIcon,
-      enable: self.chrome.pageAction.show,
-      disable: self.chrome.pageAction.hide,
-      setPopup: self.chrome.pageAction.setPopup,
+      setIcon: (_: chrome.pageAction.IconDetails) =>
+        self.chrome.pageAction.setIcon(_),
+      disable: (tabId: number) => self.chrome.pageAction.hide?.(tabId),
+      enable: (tabId: number) => self.chrome.pageAction.show?.(tabId),
+      setPopup: (_: chrome.pageAction.PopupDetails) =>
+        self.chrome.pageAction.setPopup(_),
     };
   }
 }


### PR DESCRIPTION
I really don't have a good explanation for this one.

All I know is that if these function are references without having a direct code call, they end up doing nothing in Safari. Rewrote it so that this is not the case. aAlso hide/show actions do not exist in Safari. No errors were showing up when this failed.