### PR TITLE
Fix failures on prerendering 

### DIFF
--- a/src/js/background/setupCSPListener.ts
+++ b/src/js/background/setupCSPListener.ts
@@ -31,9 +31,18 @@ export default function setupCSPListener(
           details.frameId !== 0
         ) {
           /**
-           * This seems to be unintended behavior in `webRequest` where
-           * frameId ends up as non-zero for prerendered documents.
-           * Tracking in https://bugs.chromium.org/p/chromium/issues/detail?id=1492006
+           * Chrome uses a non-main frame for prerender
+           * https://bugs.chromium.org/p/chromium/issues/detail?id=1492006
+           *
+           * This creates issues in tracking the document resources
+           * because content scripts *might* start sending messages
+           * to the background while the document is still in "prerender"-ing
+           * mode. When that happens the "sender" correctly has the frameID;
+           * however, at other times (if the user hits navigate/enter? quick enough)
+           * content script ends up sending messages from the "main" frame
+           * (frameId = 0). To handle the former case whenever the background
+           * receives a messages from a frame that is still in "prerendering"
+           * we assume the frameID to 0. See validateSender.ts
            */
           frameId = 0;
         }

--- a/src/js/background/validateSender.ts
+++ b/src/js/background/validateSender.ts
@@ -40,9 +40,15 @@ export function validateSender(
   }
 
   // If a tab is present, a frameId should always be present.
-  const frameId = sender.frameId;
+  let frameId = sender.frameId;
   if (frameId === undefined) {
     return;
+  }
+
+  // See setupCSPListener.ts for explanation
+  // @ts-expect-error Missing: type definitions in @types/chrome
+  if (sender?.documentLifecycle === 'prerender') {
+    frameId = 0;
   }
 
   return {


### PR DESCRIPTION
I have been unable to pinpoint the cause of this. But it seems that due to a recent regression CV is failing on prerendering despite me being confident in the fix back in #262.

I've made our checks more explicit here to distinguish between requests from a prerendered page and active page.

I've been unable to pinpoint the cause of this regression, I'm certain this worked before. I tried testing on Chromium versions 116, 117, 118, 119 and was able to repro there too. 


Tested with/without prerendering.

<img width="1183" alt="image" src="https://github.com/facebookincubator/meta-code-verify/assets/20268283/a4a9586b-036c-4a9d-a86d-9c24140c1d2e">

<img width="1190" alt="image" src="https://github.com/facebookincubator/meta-code-verify/assets/20268283/74d5749e-1b73-4736-adce-e8c181262e56">
