### PR TITLE
Tackle scripts claiming to belong to an invalid manifest

### DIFF
--- a/src/js/config.ts
+++ b/src/js/config.ts
@@ -129,3 +129,5 @@ export type Origin = keyof typeof ORIGIN_TYPE;
 // Firefox and Safari currently do not support CompressionStream/showSaveFilePicker
 export const DOWNLOAD_JS_ENABLED =
   'CompressionStream' in window && 'showSaveFilePicker' in window;
+
+export const MANIFEST_TIMEOUT = 45000;

--- a/src/js/content/ensureManifestWasOrWillBeLoaded.ts
+++ b/src/js/content/ensureManifestWasOrWillBeLoaded.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {MANIFEST_TIMEOUT, STATES} from '../config';
+import {updateCurrentState} from './updateCurrentState';
+
+export default function ensureManifestWasOrWillBeLoaded(
+  loadedVersions: Set<string>,
+  version: string,
+) {
+  if (loadedVersions.has(version)) {
+    return;
+  }
+  setTimeout(() => {
+    if (!loadedVersions.has(version)) {
+      updateCurrentState(
+        STATES.INVALID,
+        'Detected script from manifest that has not been loaded',
+      );
+    }
+  }, MANIFEST_TIMEOUT);
+}


### PR DESCRIPTION
Scripts from an invalid manifest can possible get CV stuck in a processing state, this ensures that CV gets into an invalid state if such a script is detected; after an adequate timeout.

<img width="1124" alt="image" src="https://github.com/facebookincubator/meta-code-verify/assets/20268283/2cf61a0c-d093-4201-a27b-169d060218a3">
