### PR TITLE
Fix SVGs rendering on Safari

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -5,6 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/* We only use objects to render out SVGs so disable pointer events */
+object {
+  pointer-events: none;
+}
+
 .action_bar {
   flex-direction: row;
   justify-content: space-between;
@@ -96,6 +101,10 @@ header {
 }
 
 .menu {
+  height: 20px;
+}
+
+.menu_button {
   cursor: pointer;
   height: 20px;
 }

--- a/src/html/popup.html
+++ b/src/html/popup.html
@@ -7,10 +7,18 @@
     <div class="state_boundary" id="valid">
       <header>
         <img class="badge" src="default_32.png" />
-        <img class="menu" src="menu-badge.svg" />
+        <div class="menu_button">
+          <object
+            class="menu"
+            type="image/svg+xml"
+            data="menu-badge.svg"></object>
+        </div>
       </header>
       <div class="content_body">
-        <img class="validated_body_image" src="validated-header.svg" />
+        <object
+          class="validated_body_image"
+          type="image/svg+xml"
+          data="validated-header.svg"></object>
         <div id="i18nValidatedStatusHeader" class="status_header"></div>
         <div id="i18nValidatedStatusMessage" class="status_message"></div>
       </div>
@@ -18,20 +26,36 @@
     <div class="state_boundary" id="loading">
       <header>
         <img class="badge" src="default_32.png" />
-        <img class="menu" src="menu-badge.svg" />
+        <div class="menu_button">
+          <object
+            class="menu"
+            type="image/svg+xml"
+            data="menu-badge.svg"></object>
+        </div>
       </header>
       <div class="content_body">
-        <img class="loading_body_image" src="loading-header.svg" />
+        <object
+          class="loading_body_image"
+          type="image/svg+xml"
+          data="loading-header.svg"></object>
         <div id="i18nCheckingStatusHeader" class="status_header"></div>
       </div>
     </div>
     <div class="state_boundary" id="warning_risk">
       <header>
         <img class="badge" src="default_32.png" />
-        <img class="menu" src="menu-badge.svg" />
+        <div class="menu_button">
+          <object
+            class="menu"
+            type="image/svg+xml"
+            data="menu-badge.svg"></object>
+        </div>
       </header>
       <div class="content_body">
-        <img class="warning_body_image" src="warning-header.svg" />
+        <object
+          class="warning_body_image"
+          type="image/svg+xml"
+          data="warning-header.svg"></object>
         <div id="i18nRiskDetectedStatusHeader" class="status_header"></div>
         <div id="i18nRiskDetectedStatusMessage" class="status_message"></div>
         <div class="action_bar">
@@ -49,10 +73,18 @@
     <div class="state_boundary" id="warning_timeout">
       <header>
         <img class="badge" src="default_32.png" />
-        <img class="menu" src="menu-badge.svg" />
+        <div class="menu_button">
+          <object
+            class="menu"
+            type="image/svg+xml"
+            data="menu-badge.svg"></object>
+        </div>
       </header>
       <div class="content_body">
-        <img class="warning_body_image" src="warning-header.svg" />
+        <object
+          class="warning_body_image"
+          type="image/svg+xml"
+          data="warning-header.svg"></object>
         <div id="i18nNetworkTimeoutStatusHeader" class="status_header"></div>
         <div id="i18nNetworkTimeoutStatusMessage" class="status_message"></div>
         <div class="action_bar">
@@ -70,10 +102,18 @@
     <div class="state_boundary" id="error">
       <header>
         <img class="badge" src="default_32.png" />
-        <img class="menu" src="menu-badge.svg" />
+        <div class="menu_button">
+          <object
+            class="menu"
+            type="image/svg+xml"
+            data="menu-badge.svg"></object>
+        </div>
       </header>
       <div class="content_body">
-        <img class="error_body_image" src="error-header.svg" />
+        <object
+          class="error_body_image"
+          type="image/svg+xml"
+          data="error-header.svg"></object>
         <div id="i18nValidationFailureStatusHeader" class="status_header"></div>
         <div class="status_message">
           <span id="i18nValidationFailureStatusMessagePartOne"></span>
@@ -97,23 +137,44 @@
           <div class="menu_title">
             <p id="i18nTopLevel"></p>
             <button id="close_menu">
-              <img class="close_button" src="x.svg" />
+              <object
+                class="close_button"
+                type="image/svg+xml"
+                data="x.svg"></object>
             </button>
           </div>
           <div class="menu_row">
-            <img class="row_image" src="circle-info.svg" />
+            <object
+              class="row_image"
+              type="image/svg+xml"
+              data="circle-info.svg"></object>
             <p id="i18nTopLevelLearnMore"></p>
-            <img class="row_nav" src="chevron-right.svg" />
+            <object
+              class="row_nav"
+              type="image/svg+xml"
+              data="chevron-right.svg"></object>
           </div>
           <div class="menu_row">
-            <img class="row_image" src="circle-download-cta.svg" />
+            <object
+              class="row_image"
+              type="image/svg+xml"
+              data="circle-download-cta.svg"></object>
             <p id="i18ndownloadSourcePrompt"></p>
-            <img class="row_nav" src="chevron-right.svg" />
+            <object
+              class="row_nav"
+              type="image/svg+xml"
+              data="chevron-right.svg"></object>
           </div>
           <div class="menu_row">
-            <img class="row_image" src="circle-download-cta.svg" />
+            <object
+              class="row_image"
+              type="image/svg+xml"
+              data="circle-download-cta.svg"></object>
             <p id="i18ndownloadReleaseSourcePrompt"></p>
-            <img class="row_nav" src="chevron-right.svg" />
+            <object
+              class="row_nav"
+              type="image/svg+xml"
+              data="chevron-right.svg"></object>
           </div>
         </div>
       </div>
@@ -124,7 +185,12 @@
           <img class="badge" src="default_32.png" />
           <p id="i18nDownloadPrompt" class="download_title"></p>
         </span>
-        <img class="menu" src="menu-badge.svg" />
+        <div class="menu_button">
+          <object
+            class="menu"
+            type="image/svg+xml"
+            data="menu-badge.svg"></object>
+        </div>
       </header>
       <div class="content_body">
         <div id="i18ndownloadSourceDescription" class="status_message"></div>

--- a/src/js/popup.ts
+++ b/src/js/popup.ts
@@ -72,8 +72,8 @@ function attachListeners(origin: string | null): void {
   }
   const learnMoreUrls = ORIGIN_TO_LEARN_MORE_PAGES[origin];
 
-  const menuButtonList = document.getElementsByClassName('menu');
-  Array.from(menuButtonList).forEach(menuButton => {
+  const menuButtonsList = document.getElementsByClassName('menu_button');
+  Array.from(menuButtonsList).forEach(menuButton => {
     menuButton.addEventListener('click', () => updateDisplay('menu'));
   });
 


### PR DESCRIPTION
Using `img` tags to render SVGs was problematic and causing bad rendering.

![image](https://github.com/facebookincubator/meta-code-verify/assets/20268283/b215a176-f8ae-424f-90af-f91408229023)

<img width="500" alt="image" src="https://github.com/facebookincubator/meta-code-verify/assets/20268283/7a2e0069-4667-4d7d-bf41-0d82f6cd3304">

