### PR TITLE
Fix popup flickering

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -220,6 +220,7 @@ header {
 
 .state_boundary {
   flex-direction: column;
+  display: none;
 }
 
 .status_header {


### PR DESCRIPTION
We're hiding popup contents on first render which was causing flickering, I've updated the initial css to not show content meant to be hidden in the first place.

Checked to make sure things still render as expected.