### PR TITLE
Fix styling of close button

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -104,9 +104,9 @@ header {
   height: 20px;
 }
 
-.menu_button {
+.menu_button,
+#close_menu {
   cursor: pointer;
-  height: 20px;
 }
 
 .menu_body {
@@ -149,6 +149,7 @@ header {
 .menu_title {
   display: flex;
   flex-direction: row;
+  align-items: center;
   justify-content: space-between;
   font-family: Optimistic Display;
   font-style: normal;

--- a/src/html/popup.html
+++ b/src/html/popup.html
@@ -136,12 +136,12 @@
         <div class="menu_right_sidebar">
           <div class="menu_title">
             <p id="i18nTopLevel"></p>
-            <button id="close_menu">
+            <div id="close_menu">
               <object
                 class="close_button"
                 type="image/svg+xml"
                 data="x.svg"></object>
-            </button>
+            </div>
           </div>
           <div class="menu_row">
             <object


### PR DESCRIPTION
Before:
<img width="295" alt="image" src="https://github.com/facebookincubator/meta-code-verify/assets/20268283/5ac32acc-664b-4764-8265-4ce2298775e3">

After:
<img width="280" alt="image" src="https://github.com/facebookincubator/meta-code-verify/assets/20268283/37060811-b544-4b6c-b3eb-da5cda3a950c">
