### PR TITLE
Fix an error that was being caused by a bad icon reference

### DIFF
--- a/src/js/config.ts
+++ b/src/js/config.ts
@@ -28,7 +28,7 @@ const ICONS = {
   DEFAULT: {
     32: 'default_32.png',
     64: 'default_64.png',
-    128: 'default_64@2x.png',
+    128: 'default_128.png',
   },
   FAILURE: {
     32: 'failure_32.png',


### PR DESCRIPTION
This referenced was missed by me when I last fixed/unified icons across manifests.

This changes addresses the following error
<img width="760" alt="Screenshot 2024-05-15 at 11 27 50 AM" src="https://github.com/facebookincubator/meta-code-verify/assets/20268283/2213b8d7-d944-41d6-906c-d42f2b847aa4">
