### PR TITLE
X-Content-Type-Options header detection is now case insensitive #334

### DIFF
--- a/src/js/background/setUpWebRequestsListener.ts
+++ b/src/js/background/setUpWebRequestsListener.ts
@@ -27,7 +27,7 @@ function checkResponseMIMEType(
   // Sniffable MIME types are a violation
   if (
     response.responseHeaders?.find(header =>
-      header.name.includes('x-content-type-options'),
+      header.name.toLowerCase().includes('x-content-type-options'),
     )?.value !== 'nosniff'
   ) {
     chrome.tabs.sendMessage(


### PR DESCRIPTION
This is a bug fix for issue #334 where the **x-content-type-options** header is only detected when the header name is lowercase. This has been fixed so that the header detection is now case-insensitive, allowing seamless support for other websites.
