### PR TITLE
Cleanup unused codepaths

### DIFF
--- a/src/js/config.ts
+++ b/src/js/config.ts
@@ -51,44 +51,6 @@ export const STATES_TO_ICONS = {
   [STATES.TIMEOUT]: ICONS.RISK,
 };
 
-/**
- * This list contains hashes of scripts inserted into the document by known extensions.
- * Because these extensions are relatively trustworthy, when these scripts fail our
- * regular validation checks we mark the page as "at risk" instead of "invalid".
- *
- * Many extensions vary their scripts from page load to page load (dynamic scripts) such that this
- * allowlist cannot work. Known instances of dynamic scripts include:
- * - Chrome - StopAll Ads
- * - Chrome - AdLock adblocker & privacy protection v0.1.30
- * - Chrome - AdBlocker Ultimate v3.7.15
- * - Chrome - DuckDuckGo Privacy Essentials v2022.2.22
- * - Chrome - Crystal Ad block v1.3.9
- * - Chrome - AdBlock — best ad blocker v4.43.0
- * - FF - Popup Blocker(strict)
- * - FF - Privacy Tweaks
- * - FF - Privacy Possum
- * - FF - Adblocker X v2.0.5
- * - FF - AdBlocker Ultimate v3.7.15
- * - FF - Cloudopt AdBlocker v2.3.0
- * - Edge - Epsilon Ad blocker v1.4.6
- * - Edge - AdBlock --- best ad blocker v4.43.0
- * - Edge - Hola ad remover v1.194.444
- * - Edge - Tau adblock v1.4.1
- */
-export const KNOWN_EXTENSION_HASHES = [
-  '727bfede71f473991faeb7f4b65632c93e7f7d17189f1b3d952cd990cd150808', // Chrome and Edge: Avast Online Security & Privacy v21.0.101
-  'c09a2e7b2fa97705c9afe890498e1f620ede4bd2968cfef7421080a8f9f0d8f9', // Chrome: Privacy Badger v2021.11.23.1
-  '04c354b90b330f4cac2678ccd311e5d2a6e8b57815510b176ddbed8d52595726', // Chrome: LastPass v4.88.0
-  '4ae6b4dcefb37952cef704c39fe3e8d675bd32c54302984e747ba6768541862a', // Chrome: Vue.js devtools v6.0.12
-  '91fecf0ca4c2260f8a18d1c371d717e656e98a0015f0206379afe662746d6009', // Chrome: Vue.js devtools v6.0.12
-  'e64b3a9472f559611158a628da06e770ce8cc3d0f8395849072a0199bae705f9', // FF: Total Adblock-Ad Blocker v2.10.0 *and* FF/Edge BitGuard v1.0
-  'c924b9ed122066e5420b125a1accb787c3856c4a422fe9bde47d1f40660271a6', // FF: Smart Blocker v1.0.2
-  '7a69d1fb29471a9962307f7882adade784141d02617e233eb366ae5f63fd9dd8', // Edge and FF: Minimal Consent v1.0.9
-  'd768396bbfda57a3defb0aeba5d9b9aefef562d8204520668f9e275c68455a0c', // Edge: Writer from Writer.com v1.63.2
-  '855e2fd1368fc12a14159e26ed3132e6567e8443f8b75081265b93845b865103', // Edge and FF: AdGuard AdBlocker v3.6.17
-  'deda33bced5f2014562e03f8c82a2a16df074a2bc6be6eceba78274056e41372', // Edge: Netcraft Extension v1.16.8
-];
-
 export const MESSAGE_TYPE = Object.freeze({
   DEBUG: 'DEBUG',
   LOAD_COMPANY_MANIFEST: 'LOAD_COMPANY_MANIFEST',

--- a/src/js/content/downloadJSArchive.ts
+++ b/src/js/content/downloadJSArchive.ts
@@ -7,7 +7,6 @@
 
 export default async function downloadJSArchive(
   sourceScripts: Map<string, ReadableStream>,
-  inlineScripts: Array<Map<string, string>>,
 ): Promise<void> {
   const fileHandle = await window.showSaveFilePicker({
     suggestedName: 'meta_source_files.gz',
@@ -30,21 +29,5 @@ export default async function downloadJSArchive(
     await compressedStream.pipeTo(writableStream, {preventClose: true});
   }
 
-  for (const inlineSrcMap of inlineScripts) {
-    const inlineHash = inlineSrcMap.keys().next().value;
-    const inlineSrc = inlineSrcMap.values().next().value;
-    const delim = delimPrefix + 'Inline Script ' + inlineHash + delimSuffix;
-    const encodedDelim = enc.encode(delim);
-    const delimStream = new window.CompressionStream('gzip');
-    const delimWriter = delimStream.writable.getWriter();
-    delimWriter.write(encodedDelim);
-    delimWriter.close();
-    await delimStream.readable.pipeTo(writableStream, {preventClose: true});
-    const inlineStream = new window.CompressionStream('gzip');
-    const writer = inlineStream.writable.getWriter();
-    writer.write(enc.encode(inlineSrc));
-    writer.close();
-    await inlineStream.readable.pipeTo(writableStream, {preventClose: true});
-  }
   writableStream.close();
 }

--- a/src/js/contentUtils.ts
+++ b/src/js/contentUtils.ts
@@ -6,7 +6,6 @@
  */
 
 import {
-  KNOWN_EXTENSION_HASHES,
   MESSAGE_TYPE,
   DOWNLOAD_JS_ENABLED,
   STATES,
@@ -63,18 +62,11 @@ export const FOUND_SCRIPTS = new Map<string, Array<ScriptDetails>>([
 const ALL_FOUND_SCRIPT_TAGS = new Set<string>();
 const FOUND_MANIFEST_VERSIONS = new Set<string>();
 
-type ScriptDetailsWithSrc = {
+type ScriptDetails = {
   otherType: string;
   src: string;
   isServiceWorker?: boolean;
 };
-type ScriptDetailsRaw = {
-  type: typeof MESSAGE_TYPE.RAW_JS;
-  rawjs: string;
-  lookupKey: string;
-  otherType: string;
-};
-type ScriptDetails = ScriptDetailsRaw | ScriptDetailsWithSrc;
 let manifestTimeoutID: string | number = '';
 
 export type RawManifestOtherHashes = {
@@ -234,14 +226,12 @@ function handleScriptNode(scriptNode: HTMLScriptElement): void {
     );
   }
 
-  const scriptDetails = {
-    src: scriptNode.src,
-    otherType,
-  };
-
   ALL_FOUND_SCRIPT_TAGS.add(scriptNode.src);
   ensureManifestWasOrWillBeLoaded(FOUND_MANIFEST_VERSIONS, version);
-  pushToOrCreateArrayInMap(FOUND_SCRIPTS, version, scriptDetails);
+  pushToOrCreateArrayInMap(FOUND_SCRIPTS, version, {
+    src: scriptNode.src,
+    otherType,
+  });
 
   updateCurrentState(STATES.PROCESSING);
 }
@@ -346,7 +336,7 @@ export const scanForScripts = (): void => {
 };
 
 async function processJSWithSrc(
-  script: ScriptDetailsWithSrc,
+  script: ScriptDetails,
   version: string,
 ): Promise<{
   valid: boolean;
@@ -426,73 +416,30 @@ export const processFoundJS = async (version: string): Promise<void> => {
   });
   let pendingScriptCount = scripts.length;
   for (const script of scripts) {
-    if ('src' in script) {
-      // ScriptDetailsWithSrc
-      await processJSWithSrc(script, version).then(response => {
-        pendingScriptCount--;
-        if (response.valid) {
-          if (pendingScriptCount == 0) {
-            updateCurrentState(STATES.VALID);
-          }
-        } else {
-          if (response.type === 'EXTENSION') {
-            updateCurrentState(STATES.RISK);
-          } else {
-            updateCurrentState(
-              STATES.INVALID,
-              `Invalid ScriptDetailsWithSrc ${script.src}`,
-            );
-          }
+    await processJSWithSrc(script, version).then(response => {
+      pendingScriptCount--;
+      if (response.valid) {
+        if (pendingScriptCount == 0) {
+          updateCurrentState(STATES.VALID);
         }
-        sendMessageToBackground({
-          type: MESSAGE_TYPE.DEBUG,
-          log:
-            'processed JS with SRC response is ' +
-            JSON.stringify(response).substring(0, 500),
-          src: script.src,
-        });
+      } else {
+        if (response.type === 'EXTENSION') {
+          updateCurrentState(STATES.RISK);
+        } else {
+          updateCurrentState(
+            STATES.INVALID,
+            `Invalid ScriptDetailsWithSrc ${script.src}`,
+          );
+        }
+      }
+      sendMessageToBackground({
+        type: MESSAGE_TYPE.DEBUG,
+        log:
+          'processed JS with SRC response is ' +
+          JSON.stringify(response).substring(0, 500),
+        src: script.src,
       });
-    } else {
-      // ScriptDetailsRaw
-      sendMessageToBackground(
-        {
-          type: script.type,
-          rawjs: script.rawjs.trimStart(),
-          origin: getCurrentOrigin(),
-          version: version,
-        },
-        response => {
-          pendingScriptCount--;
-          const inlineScriptMap = new Map();
-          if (response.valid) {
-            inlineScriptMap.set(response.hash, script.rawjs);
-            INLINE_SCRIPTS.push(inlineScriptMap);
-            if (pendingScriptCount == 0) {
-              updateCurrentState(STATES.VALID);
-            }
-          } else {
-            inlineScriptMap.set('hash not in manifest', script.rawjs);
-            INLINE_SCRIPTS.push(inlineScriptMap);
-            if (
-              response.hash &&
-              KNOWN_EXTENSION_HASHES.includes(response.hash)
-            ) {
-              updateCurrentState(STATES.RISK);
-            } else {
-              updateCurrentState(STATES.INVALID, 'Invalid ScriptDetailsRaw');
-            }
-          }
-          sendMessageToBackground({
-            type: MESSAGE_TYPE.DEBUG,
-            log:
-              'processed the RAW_JS, response is ' +
-              response.hash +
-              ' ' +
-              JSON.stringify(response).substring(0, 500),
-          });
-        },
-      );
-    }
+    });
   }
   window.setTimeout(() => processFoundJS(version), 3000);
 };

--- a/src/js/contentUtils.ts
+++ b/src/js/contentUtils.ts
@@ -45,12 +45,6 @@ type ContentScriptConfig = {
 let originConfig: ContentScriptConfig | null = null;
 
 const SOURCE_SCRIPTS = new Map();
-/**
- * using an array of maps, as we're using the same key for inline scripts
- * this will eventually be removed, once inline scripts are removed from the
- * page load
- * */
-const INLINE_SCRIPTS: Array<Map<string, string>> = [];
 
 export const UNINITIALIZED = 'UNINITIALIZED';
 const BOTH = 'BOTH';
@@ -505,7 +499,7 @@ export function startFor(origin: Origin, config: ContentScriptConfig): void {
 
 chrome.runtime.onMessage.addListener(request => {
   if (request.greeting === 'downloadSource' && DOWNLOAD_JS_ENABLED) {
-    downloadJSArchive(SOURCE_SCRIPTS, INLINE_SCRIPTS);
+    downloadJSArchive(SOURCE_SCRIPTS);
   } else if (request.greeting === 'nocacheHeaderFound') {
     updateCurrentState(
       STATES.INVALID,


### PR DESCRIPTION
More missed code from #323

We don't allow any inline scripts given `unsafe-inline` checks, so it makes no sense to check the content of these scripts.

This also allows us to remove logic that supported scripts inserted by other extensions.

Tested on FB/MSGR/IG/WA

