### PR TITLE
When checking CSP ensure other whitespace characters are accounted for 

### DIFF
--- a/src/js/__tests__/parseCSPString-test.js
+++ b/src/js/__tests__/parseCSPString-test.js
@@ -67,4 +67,16 @@ describe('parseCSPString', () => {
       ]),
     );
   });
+  it('Correctly parses other whitespace chars', () => {
+    expect(
+      parseCSPString(
+        `default-src\t'self' blob:;` + `script-src 'self'\f'wasm-unsafe-eval';`,
+      ),
+    ).toEqual(
+      new Map([
+        ['default-src', new Set(["'self'", 'blob:'])],
+        ['script-src', new Set(["'self'", "'wasm-unsafe-eval'"])],
+      ]),
+    );
+  });
 });

--- a/src/js/content/parseCSPString.ts
+++ b/src/js/content/parseCSPString.ts
@@ -11,7 +11,7 @@ export function parseCSPString(csp: string): Map<string, Set<string>> {
     const [directive, ...values] = directiveString
       .trim()
       .toLowerCase()
-      .split(' ');
+      .split(/\s+/);
     // Ignore subsequent keys for a directive, if it's specified more than once
     if (!map.has(directive)) {
       map.set(directive, new Set(values));


### PR DESCRIPTION
https://w3c.github.io/webappsec-csp/#framework-directives

According to the spec whitespace characters can be used to separate CSP directive values

<img width="842" alt="image" src="https://github.com/user-attachments/assets/948a9c54-0d04-4011-aab7-63ec1faedb45" />
