### PR TITLE
Add history tracking storage functionality for violation

### DIFF
--- a/config/v2/manifest.json
+++ b/config/v2/manifest.json
@@ -54,6 +54,7 @@
     ],
     "permissions": [
         "webRequest",
+        "storage",
         "https://*.privacy-auditability.cloudflare.com/*",
         "https://static.xx.fbcdn.net/",
         "https://static.cdninstagram.com/",

--- a/config/v3/manifest.json
+++ b/config/v3/manifest.json
@@ -52,7 +52,8 @@
         }
     ],
     "permissions": [
-        "webRequest"
+        "webRequest",
+        "storage"
     ],
     "host_permissions": [
         "https://*.privacy-auditability.cloudflare.com/",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@rollup/plugin-eslint": "^9.0.5",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-typescript": "^11.1.5",
-    "@types/chrome": "^0.0.248",
+    "@types/chrome": "^0.1.4",
     "@types/jest": "^29.4.0",
     "@typescript-eslint/eslint-plugin": "^6.8.0",
     "@typescript-eslint/parser": "^6.8.0",

--- a/src/js/background/historyManager.ts
+++ b/src/js/background/historyManager.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import type {Origin} from '../config';
+
+const HISTORY_TTL_MSEC = 120 * 86400 * 1000; // 120 Days
+
+const TAB_TO_VIOLATING_SRCS = new Map<
+  number,
+  Set<{
+    origin: Origin;
+    version: string;
+    hash: string;
+  }>
+>();
+
+export async function upsertInvalidRecord(
+  tabID: number,
+  creationTime: number,
+): Promise<void> {
+  const tab = await chrome.tabs.get(tabID);
+  const tabIDKey = String(tabID);
+  const entry = await chrome.storage.local.get(tabIDKey);
+
+  if (Object.keys(entry).length !== 0) {
+    creationTime = entry[tabIDKey].creationTime;
+  }
+
+  return chrome.storage.local.set({
+    [tabIDKey]: {
+      creationTime,
+      violations: Array.from(TAB_TO_VIOLATING_SRCS.get(tabID) ?? new Set()),
+      url: tab.url,
+    },
+  });
+}
+
+export async function trackViolationForTab(
+  tabId: number,
+  rawSource: string,
+  origin: Origin,
+  version: string,
+  hash: string,
+) {
+  if (!TAB_TO_VIOLATING_SRCS.has(tabId)) {
+    TAB_TO_VIOLATING_SRCS.set(tabId, new Set());
+  }
+  TAB_TO_VIOLATING_SRCS.get(tabId)?.add({
+    origin,
+    version,
+    hash,
+  });
+
+  const opfsRoot = await navigator.storage.getDirectory();
+  // Make a directory for this tabId
+  const dir = await opfsRoot.getDirectoryHandle(String(tabId), {create: true});
+  // Create one file per violating src keyed by the hash, gzip the contents
+  const file = await dir.getFileHandle(hash, {create: true});
+  const writable = await file.createWritable();
+  const encoder = new TextEncoder();
+  const uint8 = encoder.encode(rawSource);
+  const stream = new Blob([uint8]).stream();
+  const compressedStream = stream.pipeThrough(new CompressionStream('gzip'));
+
+  await compressedStream.pipeTo(writable);
+}
+
+export async function setUpHistoryCleaner(): Promise<void> {
+  const now = Date.now();
+  const keys = await chrome.storage.local.getKeys();
+  const entries = await chrome.storage.local.get(keys);
+
+  const entriesToDelete = Object.entries(entries)
+    .filter(([_keys, entry]) => now - entry.creationTime >= HISTORY_TTL_MSEC)
+    .map(entry => entry[0]);
+
+  if (entriesToDelete.length > 0) {
+    const opfsRoot = await navigator.storage.getDirectory();
+    await chrome.storage.local.remove(entriesToDelete);
+    console.log('Removing entries from extension storage', entriesToDelete);
+    entriesToDelete.forEach(async key => {
+      await opfsRoot.removeEntry(key, {recursive: true}).then(() => {
+        console.log(`Removed hashes for entry ${key}`);
+      });
+    });
+  }
+}

--- a/src/js/background/setUpWebRequestsListener.ts
+++ b/src/js/background/setUpWebRequestsListener.ts
@@ -6,7 +6,7 @@
  */
 
 const isMetaInitiatedResponse = (
-  response: chrome.webRequest.WebResponseCacheDetails,
+  response: chrome.webRequest.OnResponseStartedDetails,
 ) => {
   const initiator = response.initiator;
   if (!initiator) {
@@ -22,7 +22,7 @@ const isMetaInitiatedResponse = (
 };
 
 function checkResponseMIMEType(
-  response: chrome.webRequest.WebResponseCacheDetails,
+  response: chrome.webRequest.OnResponseStartedDetails,
 ): void {
   // Sniffable MIME types are a violation
   if (

--- a/src/js/background/setupCSPListener.ts
+++ b/src/js/background/setupCSPListener.ts
@@ -23,9 +23,7 @@ export default function setupCSPListener(
         );
         let frameId = details.frameId;
         if (
-          // @ts-expect-error Missing: type definitions in @types/chrome
           details?.documentLifecycle === 'prerender' &&
-          // @ts-expect-error Missing: type definitions in @types/chrome
           details?.frameType === 'outermost_frame' &&
           details.type === 'main_frame' &&
           details.frameId !== 0
@@ -81,6 +79,7 @@ export default function setupCSPListener(
           });
         }
       }
+      return undefined;
     },
     {
       types: ['main_frame', 'sub_frame'],

--- a/src/js/background/tab_state_tracker/TabStateMachine.ts
+++ b/src/js/background/tab_state_tracker/TabStateMachine.ts
@@ -16,6 +16,7 @@ import {
 
 import StateMachine from './StateMachine';
 import FrameStateMachine from './FrameStateMachine';
+import {upsertInvalidRecord} from '../historyManager';
 import {sendMessageToBackground} from '../../shared/sendMessageToBackground';
 
 function getChromeV3Action() {
@@ -41,11 +42,13 @@ export default class TabStateMachine extends StateMachine {
   private _tabId: number;
   private _origin: Origin;
   private _frameStates: {[key: number]: FrameStateMachine};
+  private _creationTime: number;
 
   constructor(tabId: number, origin: Origin) {
     super();
     this._tabId = tabId;
     this._origin = origin;
+    this._creationTime = Date.now();
     this._frameStates = {};
   }
 
@@ -73,6 +76,9 @@ export default class TabStateMachine extends StateMachine {
       )
     ) {
       return;
+    }
+    if (newState === STATES.INVALID) {
+      upsertInvalidRecord(this._tabId, this._creationTime);
     }
     super.updateStateIfValid(newState);
   }

--- a/src/js/content/checkWorkerEndpointCSP.ts
+++ b/src/js/content/checkWorkerEndpointCSP.ts
@@ -76,7 +76,7 @@ export function areBlobAndDataExcluded(cspHeaders: string[]): boolean {
  * See checkWorkerEndpointCSP for enforcement.
  */
 export function isWorkerEndpointCSPValid(
-  response: chrome.webRequest.WebResponseCacheDetails,
+  response: chrome.webRequest.OnResponseStartedDetails,
   documentWorkerCSPs: Array<Set<string>>,
   origin: Origin,
 ): [true] | [false, string] {
@@ -112,7 +112,7 @@ export function isWorkerEndpointCSPValid(
 }
 
 export function checkWorkerEndpointCSP(
-  response: chrome.webRequest.WebResponseCacheDetails,
+  response: chrome.webRequest.OnResponseStartedDetails,
   documentWorkerCSPs: Array<Set<string>>,
   origin: Origin,
 ): void {

--- a/src/js/content/hasVaryServiceWorkerHeader.ts
+++ b/src/js/content/hasVaryServiceWorkerHeader.ts
@@ -6,7 +6,7 @@
  */
 
 export function hasVaryServiceWorkerHeader(
-  response: chrome.webRequest.WebResponseCacheDetails,
+  response: chrome.webRequest.OnResponseStartedDetails,
 ): boolean {
   return (
     response.responseHeaders?.find(

--- a/src/js/shared/getCSPHeadersFromWebRequestResponse.ts
+++ b/src/js/shared/getCSPHeadersFromWebRequestResponse.ts
@@ -6,7 +6,7 @@
  */
 
 export function getCSPHeadersFromWebRequestResponse(
-  response: chrome.webRequest.WebResponseHeadersDetails,
+  response: chrome.webRequest.OnHeadersReceivedDetails,
   reportHeader = false,
 ): Array<chrome.webRequest.HttpHeader> {
   const responseHeaders = response.responseHeaders;

--- a/yarn.lock
+++ b/yarn.lock
@@ -744,10 +744,10 @@
   dependencies:
     "@babel/types" "^7.20.7"
 
-"@types/chrome@^0.0.248":
-  version "0.0.248"
-  resolved "https://registry.yarnpkg.com/@types/chrome/-/chrome-0.0.248.tgz#fdc188a4b7ab8cfd2c49cb666214ecab81599002"
-  integrity sha512-qtBzxZD1v3eWZn8XxH1i07pAhzJDHnxJBBVy7bmntXxXKxjzNXYxD41teqa5yOcX/Yy8brRFGZESEzGoINvBDg==
+"@types/chrome@^0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@types/chrome/-/chrome-0.1.4.tgz#74a3a6c892e2c5d0a98997c4f038cb67cfbb0fa9"
+  integrity sha512-vfISO7SPppN3OKVUqWujtZ4vux3nhDqKaHYEHgfQuPARHuWJ3jjyc1s13H0ckzEc86/neTkCl1TeW72UK6jYKA==
   dependencies:
     "@types/filesystem" "*"
     "@types/har-format" "*"
@@ -758,16 +758,16 @@
   integrity sha512-CS2rOaoQ/eAgAfcTfq6amKG7bsN+EMcgGY4FAFQdvSj2y1ixvOZTUA9mOtCai7E1SYu283XNw7urKK30nP3wkQ==
 
 "@types/filesystem@*":
-  version "0.0.34"
-  resolved "https://registry.yarnpkg.com/@types/filesystem/-/filesystem-0.0.34.tgz#9b0d0d791ab6b217528cce8d391764b4b47607bf"
-  integrity sha512-La4bGrgck8/rosDUA1DJJP8hrFcKq0BV6JaaVlNnOo1rJdJDcft3//slEbAmsWNUJwXRCc0DXpeO40yuATlexw==
+  version "0.0.36"
+  resolved "https://registry.yarnpkg.com/@types/filesystem/-/filesystem-0.0.36.tgz#7227c2d76bfed1b21819db310816c7821d303857"
+  integrity sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA==
   dependencies:
     "@types/filewriter" "*"
 
 "@types/filewriter@*":
-  version "0.0.31"
-  resolved "https://registry.yarnpkg.com/@types/filewriter/-/filewriter-0.0.31.tgz#a5a256646bd98209baf9aa32073047f84f4c3f3f"
-  integrity sha512-12df1utOvPC80+UaVoOO1d81X8pa5MefHNS+gWX9R2ucSESpMz9K5QwlTWDGKASrzCpSFwj7NPYh+nTsolgEGA==
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/@types/filewriter/-/filewriter-0.0.33.tgz#d9d611db9d9cd99ae4e458de420eeb64ad604ea8"
+  integrity sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==
 
 "@types/graceful-fs@^4.1.3":
   version "4.1.8"
@@ -777,9 +777,9 @@
     "@types/node" "*"
 
 "@types/har-format@*":
-  version "1.2.14"
-  resolved "https://registry.yarnpkg.com/@types/har-format/-/har-format-1.2.14.tgz#292e55d52be8659c8486316a0ae439760617e0a3"
-  integrity sha512-pEmBAoccWvO6XbSI8A7KvIDGEoKtlLWtdqVCKoVBcCDSFvR4Ijd7zGLu7MWGEqk2r8D54uWlMRt+VZuSrfFMzQ==
+  version "1.2.16"
+  resolved "https://registry.yarnpkg.com/@types/har-format/-/har-format-1.2.16.tgz#b71ede8681400cc08b3685f061c31e416cf94944"
+  integrity sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.5"


### PR DESCRIPTION
* Users should be able to look back at previous failures to investigate the cause of violations
* Use a combination [Extension Storage](https://developer.chrome.com/docs/extensions/reference/api/storage) and [OPFS](https://developer.mozilla.org/en-US/docs/Web/API/File_System_API/Origin_private_file_system) to keep track of violations
* This PR incorporates the use of extension storage to keep track of violations per tab/session including hashes which where the cause of failures
* The source code of said hashes will be stored in OPFS
* This includes a cleanup mechanism to remove entries older than 120 days, UI will allow manual deletion of entries
* UI to come separately
* This also includes a bump of `@types/chrome` which was needed for some of the used APIs

<img width="1439" height="1244" alt="image" src="https://github.com/user-attachments/assets/072a4e8f-5d45-46d2-bd6e-eda4afe6ff5d" />


<img width="1257" height="439" alt="Screenshot 2025-08-20 at 5 48 54 PM" src="https://github.com/user-attachments/assets/59ba56b4-6c5d-4b96-9b9b-b5073a03ed6e" />
<img width="2343" height="509" alt="Screenshot 2025-08-20 at 5 52 37 PM" src="https://github.com/user-attachments/assets/ab8cedb1-b8c1-417f-99fb-1b151a4f32e5" />

Cleanup

<img width="867" height="109" alt="Screenshot 2025-08-20 at 5 24 26 PM" src="https://github.com/user-attachments/assets/a6e0dc39-fc5e-43c2-92ce-cfe83c466e85" />


