### PR TITLE
Rewrite UI with Web Components

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -83,15 +83,9 @@
 	"i18nValidationFailureStatusHeader": {
 		"message": "Validation Failure"
 	},
-	"i18nValidationFailureStatusMessagePartOne": {
-		"message": "The source code on this page doesn't match what was sent to other users. "
-	},
-	"i18nstatusValidationFailureMessageHighlighted": {
-		"message": "Download the source code"
-	},
-	"i18nValidationFailureStatusMessagePartTwo": {
-		"message": "to examine why the page was not validated."
-	},
+  "i18nValidationFailureStatusMessage": {
+    "message": "The source code on this page doesn't match what was sent to other users. Download the source code to examine why the page was not validated."
+  },
 	"i18nAnomalyLearnMoreButton": {
 		"message": "Learn More"
 	},

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -10,14 +10,19 @@ object {
   pointer-events: none;
 }
 
-.action_bar {
-  flex-direction: row;
-  justify-content: space-between;
-  margin: 24px 13px 0 13px;
+body {
+  width: 262px;
+  margin: 0;
 }
 
-.badge {
+.badge,
+.menu {
   height: 20px;
+}
+
+.body_image {
+  height: 32px;
+  width: 158px;
 }
 
 .content_body {
@@ -25,16 +30,28 @@ object {
   display: flex;
   justify-content: center;
   flex-direction: column;
+  margin-bottom: 16px;
+  padding-top: 24px;
 }
 
-.anomaly_learn_more_button,
-.download_button {
+.action_bar {
+  flex-direction: row;
+  display: flex;
+  justify-content: space-evenly;
+  margin-top: 16px;
+  width: 100%;
+  gap: 12px;
+	padding: 0 12px;
+	box-sizing: border-box;
+}
+
+.button {
+  flex: 1;
   border: 1px solid #cbd2d9;
   box-sizing: border-box;
   border-radius: 4px;
+  cursor: pointer;
   height: 36px;
-  width: 230px;
-  background: #1c2b33;
   font-family: SF Pro Text;
   font-style: normal;
   font-weight: 500;
@@ -42,32 +59,66 @@ object {
   line-height: 20px;
   text-align: center;
   letter-spacing: -0.23px;
+}
+
+.primary_button {
+  background: #1c2b33;
   color: #ffffff;
 }
 
-.risk_learn_more_button,
-.timeout_learn_more_button {
-  border: 1px solid #cbd2d9;
-  box-sizing: border-box;
-  border-radius: 4px;
-  height: 36px;
-  width: 111px;
+.secondary_button {
   background: #ffffff;
-  font-family: SF Pro Text;
-  font-style: normal;
-  font-weight: 500;
-  font-size: 15px;
-  line-height: 20px;
-  text-align: center;
-  letter-spacing: -0.23px;
   color: #1c2b33;
 }
 
-.download_header {
+header {
   display: flex;
+  justify-content: space-between;
+  padding: 16px 16px 0 16px;
 }
 
-.download_title {
+.menu_button,
+#close_menu {
+  cursor: pointer;
+}
+
+
+.state_boundary {
+  flex-direction: column;
+  display: none;
+}
+
+.status_header {
+  font-family: SF Pro Text;
+  font-style: normal;
+  font-weight: 600;
+  font-size: 13px;
+  line-height: 18px;
+  text-align: center;
+  letter-spacing: -0.08px;
+  color: #1c2b33;
+  margin-top: 12px;
+}
+
+.status_message {
+  font-family: SF Pro Text;
+  font-style: normal;
+  font-weight: normal;
+  font-size: 13px;
+  line-height: 18px;
+  text-align: center;
+  letter-spacing: -0.08px;
+  color: #63788a;
+  margin: 0 36px;
+}
+
+.header_title {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.header_label {
   font-family: Optimistic Display;
   font-style: normal;
   font-weight: bold;
@@ -77,44 +128,11 @@ object {
   color: #000000;
   height: 22px;
   width: 84px;
-  margin: 0px 0px 0px 12px;
-  padding-bottom: 21px;
-}
-
-.download_body {
-  width: 262px;
-  height: 164px;
-  padding-bottom: 12px;
-}
-
-.error_body {
-  width: 262px;
-  height: 288px;
-  background: #ffffff;
   margin: 0;
+  padding: 0;
 }
 
-header {
-  display: flex;
-  justify-content: space-between;
-  padding: 16px 16px 0 16px;
-}
-
-.menu {
-  height: 20px;
-}
-
-.menu_button,
-#close_menu {
-  cursor: pointer;
-}
-
-.menu_body {
-  height: 227px;
-  width: 256px;
-  margin: 0px;
-}
-
+/* Menu Page */
 .menu_right_sidebar {
   display: flex;
   flex-direction: column;
@@ -126,6 +144,7 @@ header {
 
 .menu_row {
   display: flex;
+  cursor: pointer;
   flex-direction: row;
   align-items: center;
   padding: 8px 16px;
@@ -185,36 +204,6 @@ header {
   margin: 13px 12px 0 15px;
 }
 
-.loading_body {
-  width: 257px;
-  height: 154px;
-  background: #ffffff;
-  margin: 0;
-}
-
-.loading_body_image {
-  height: 32px;
-  margin-top: 24px;
-  width: 158px;
-}
-
-.retry_button {
-  border: 1px solid #cbd2d9;
-  box-sizing: border-box;
-  border-radius: 4px;
-  height: 36px;
-  width: 111px;
-  background: #1c2b33;
-  font-family: SF Pro Text;
-  font-style: normal;
-  font-weight: 500;
-  font-size: 15px;
-  line-height: 20px;
-  text-align: center;
-  letter-spacing: -0.23px;
-  color: #ffffff;
-}
-
 .row_image {
   flex: none;
   order: 0;
@@ -226,72 +215,4 @@ header {
   order: 2;
   flex-grow: 0;
   margin: 0px 12px;
-}
-
-.state_boundary {
-  flex-direction: column;
-  display: none;
-}
-
-.status_header {
-  font-family: SF Pro Text;
-  font-style: normal;
-  font-weight: 600;
-  font-size: 13px;
-  line-height: 18px;
-
-  text-align: center;
-  letter-spacing: -0.08px;
-
-  color: #1c2b33;
-  margin-top: 12px;
-}
-
-.status_message {
-  font-family: SF Pro Text;
-  font-style: normal;
-  font-weight: normal;
-  font-size: 13px;
-  line-height: 18px;
-  text-align: center;
-  letter-spacing: -0.08px;
-  color: #63788a;
-  margin: 0 36px;
-}
-
-.status_message_highlight {
-  color: #1c2b33;
-}
-
-.valid_body {
-  width: 262px;
-  height: 164px;
-  background: #ffffff;
-  margin: 0;
-}
-
-.validated_body_image {
-  height: 32px;
-  margin-top: 24px;
-  width: 158px;
-}
-
-.warning_risk_body {
-  width: 262px;
-  height: 270px;
-  background: #ffffff;
-  margin: 0;
-}
-
-.warning_timeout_body {
-  width: 262px;
-  height: 216px;
-  background: #ffffff;
-  margin: 0;
-}
-
-.warning_body_image {
-  height: 32px;
-  margin-top: 24px;
-  width: 158px;
 }

--- a/src/html/popup.html
+++ b/src/html/popup.html
@@ -4,132 +4,48 @@
     <link rel="stylesheet" href="popup.css" />
   </head>
   <body class="valid_body">
-    <div class="state_boundary" id="valid">
-      <header>
-        <img class="badge" src="default_32.png" />
-        <div class="menu_button">
-          <object
-            class="menu"
-            type="image/svg+xml"
-            data="menu-badge.svg"></object>
-        </div>
-      </header>
-      <div class="content_body">
-        <object
-          class="validated_body_image"
-          type="image/svg+xml"
-          data="validated-header.svg"></object>
-        <div id="i18nValidatedStatusHeader" class="status_header"></div>
-        <div id="i18nValidatedStatusMessage" class="status_message"></div>
-      </div>
-    </div>
-    <div class="state_boundary" id="loading">
-      <header>
-        <img class="badge" src="default_32.png" />
-        <div class="menu_button">
-          <object
-            class="menu"
-            type="image/svg+xml"
-            data="menu-badge.svg"></object>
-        </div>
-      </header>
-      <div class="content_body">
-        <object
-          class="loading_body_image"
-          type="image/svg+xml"
-          data="loading-header.svg"></object>
-        <div id="i18nCheckingStatusHeader" class="status_header"></div>
-      </div>
-    </div>
-    <div class="state_boundary" id="warning_risk">
-      <header>
-        <img class="badge" src="default_32.png" />
-        <div class="menu_button">
-          <object
-            class="menu"
-            type="image/svg+xml"
-            data="menu-badge.svg"></object>
-        </div>
-      </header>
-      <div class="content_body">
-        <object
-          class="warning_body_image"
-          type="image/svg+xml"
-          data="warning-header.svg"></object>
-        <div id="i18nRiskDetectedStatusHeader" class="status_header"></div>
-        <div id="i18nRiskDetectedStatusMessage" class="status_message"></div>
-        <div class="action_bar">
-          <button
-            id="i18nRiskDetectedLearnMoreButton"
-            class="risk_learn_more_button"
-            type="button"></button>
-          <button
-            id="i18nRiskDetectedRetryButton"
-            class="retry_button"
-            type="button"></button>
-        </div>
-      </div>
-    </div>
-    <div class="state_boundary" id="warning_timeout">
-      <header>
-        <img class="badge" src="default_32.png" />
-        <div class="menu_button">
-          <object
-            class="menu"
-            type="image/svg+xml"
-            data="menu-badge.svg"></object>
-        </div>
-      </header>
-      <div class="content_body">
-        <object
-          class="warning_body_image"
-          type="image/svg+xml"
-          data="warning-header.svg"></object>
-        <div id="i18nNetworkTimeoutStatusHeader" class="status_header"></div>
-        <div id="i18nNetworkTimeoutStatusMessage" class="status_message"></div>
-        <div class="action_bar">
-          <button
-            id="i18nTimeoutLearnMoreButton"
-            class="timeout_learn_more_button"
-            type="button"></button>
-          <button
-            id="i18nTimeoutRetryButton"
-            class="retry_button"
-            type="button"></button>
-        </div>
-      </div>
-    </div>
-    <div class="state_boundary" id="error">
-      <header>
-        <img class="badge" src="default_32.png" />
-        <div class="menu_button">
-          <object
-            class="menu"
-            type="image/svg+xml"
-            data="menu-badge.svg"></object>
-        </div>
-      </header>
-      <div class="content_body">
-        <object
-          class="error_body_image"
-          type="image/svg+xml"
-          data="error-header.svg"></object>
-        <div id="i18nValidationFailureStatusHeader" class="status_header"></div>
-        <div class="status_message">
-          <span id="i18nValidationFailureStatusMessagePartOne"></span>
-          <span
-            id="i18nstatusValidationFailureMessageHighlighted"
-            class="status_message_highlight"></span>
-          <span id="i18nValidationFailureStatusMessagePartTwo"></span>
-        </div>
-        <div class="action_bar">
-          <button
-            id="i18nAnomalyLearnMoreButton"
-            class="anomaly_learn_more_button"
-            type="button"></button>
-        </div>
-      </div>
-    </div>
+    <state-element
+      inner-id="valid"
+      type="validated"
+      status-header="i18nValidatedStatusHeader"
+      status-message="i18nValidatedStatusMessage"></state-element>
+    <state-element
+      inner-id="loading"
+      type="loading"
+      status-header="i18nCheckingStatusHeader"></state-element>
+    <state-element
+      inner-id="warning_risk"
+      type="warning"
+      status-header="i18nRiskDetectedStatusHeader"
+      status-message="i18nRiskDetectedStatusMessage"
+      primary-button-id="i18nRiskDetectedRetryButton"
+      primary-button-action="retry"
+      secondary-button-id="i18nRiskDetectedLearnMoreButton"
+      secondary-button-action="learn_more"></state-element>
+    <state-element
+      inner-id="warning_timeout"
+      type="warning"
+      status-header="i18nNetworkTimeoutStatusHeader"
+      status-message="i18nNetworkTimeoutStatusMessage"
+      primary-button-id="i18nTimeoutRetryButton"
+      primary-button-action="retry"
+      secondary-button-id="i18nTimeoutLearnMoreButton"
+      secondary-button-action="learn_more"></state-element>
+    <state-element
+      inner-id="error"
+      type="error"
+      status-header="i18nValidationFailureStatusHeader"
+      status-message="i18nValidationFailureStatusMessage"
+      secondary-button-id="i18nAnomalyLearnMoreButton"
+      secondary-button-action="learn_more"
+      primary-button-id="i18nDownloadPrompt"
+      primary-button-action="download"></state-element>
+    <state-element
+      inner-id="download"
+      header-message="i18nDownloadPrompt"
+      status-message="i18ndownloadSourceDescription"
+      primary-button-id="i18nDownloadSourceButton"
+      primary-button-action="download"></state-element>
     <div class="state_boundary" id="menu">
       <div class="menu_top_level">
         <img class="badge" src="default_32.png" />
@@ -176,29 +92,6 @@
               type="image/svg+xml"
               data="chevron-right.svg"></object>
           </div>
-        </div>
-      </div>
-    </div>
-    <div class="state_boundary" id="download">
-      <header>
-        <span class="download_header">
-          <img class="badge" src="default_32.png" />
-          <p id="i18nDownloadPrompt" class="download_title"></p>
-        </span>
-        <div class="menu_button">
-          <object
-            class="menu"
-            type="image/svg+xml"
-            data="menu-badge.svg"></object>
-        </div>
-      </header>
-      <div class="content_body">
-        <div id="i18ndownloadSourceDescription" class="status_message"></div>
-        <div class="action_bar">
-          <button
-            id="i18nDownloadSourceButton"
-            class="download_button"
-            type="button"></button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Rewrite UI using Web Components (https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_custom_elements)

* The UI is really hard to work with and in preparation for some upcoming changes I took the liberty to rewrite it using Web Components
* Component: `state-element` handles displaying different extension states: 'loading', 'warning_risk', 'warning_timeout', 'error', 'valid', 'download'. `menu` state will be handled in a subsequent PR
* Component: `popup-header` subcomponent within `state-elemnt` that renders the top header
* Standardized buttons/layouts inside a state

With Download support:
<video src="https://github.com/user-attachments/assets/6287ed5c-d943-4d34-9e42-50b462e8c0c0" width="300" />

Without Download support:

<video src="https://github.com/user-attachments/assets/e248ac4d-8e4d-4ffc-937b-6bf74716295b" width="300" />


Note: The odd menu page repaints are unrelated to these changes.

