### PR TITLE
Fix multiple issues relating to async/await

### DIFF
--- a/src/js/background.ts
+++ b/src/js/background.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import './globals';
+
 import {DYNAMIC_STRING_MARKER, Origin, STATES} from './config';
 import {MESSAGE_TYPE, ORIGIN_HOST} from './config';
 

--- a/src/js/background/historyManager.ts
+++ b/src/js/background/historyManager.ts
@@ -22,9 +22,7 @@ export async function getRecords(): Promise<
     [string, {creationTime: number; violations: Array<Violation>; url: string}]
   >
 > {
-  const tabIDs = await chrome.storage.local.getKeys();
-  const entries = await chrome.storage.local.get(tabIDs);
-  return Object.entries(entries);
+  return Object.entries(await chrome.storage.local.get(null));
 }
 
 export async function downloadHashSource(
@@ -105,10 +103,8 @@ export async function trackViolationForTab(
 
 export async function setUpHistoryCleaner(): Promise<void> {
   const now = Date.now();
-  const keys = await chrome.storage.local.getKeys();
-  const entries = await chrome.storage.local.get(keys);
 
-  const entriesToDelete = Object.entries(entries)
+  const entriesToDelete = (await getRecords())
     .filter(([_keys, entry]) => now - entry.creationTime >= HISTORY_TTL_MSEC)
     .map(entry => entry[0]);
 

--- a/src/js/content.ts
+++ b/src/js/content.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import './globals';
+
 import {
   MESSAGE_TYPE,
   DOWNLOAD_SRC_ENABLED,

--- a/src/js/globals.ts
+++ b/src/js/globals.ts
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities
+// To enable Promise APIs we need to use `browser` outside of Chrome
+self.chrome = self.browser ?? self.chrome;

--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -22,8 +22,6 @@ declare global {
     showSaveFilePicker: (_: {
       suggestedName: string;
     }) => Promise<FileSystemFileHandle>;
-  }
-  interface FileSystemFileHandle {
-    createWritable: () => Promise<WritableStream>;
+    browser: typeof chrome;
   }
 }

--- a/src/js/popup/popup.ts
+++ b/src/js/popup/popup.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import '../globals';
+
 import type {Origin, State} from '../config';
 import {
   DOWNLOAD_SRC_ENABLED,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,6 @@
     "moduleResolution": "node",
     "noFallthroughCasesInSwitch": true,
     "strict": true,
-    "target": "ES6"
+    "target": "ES2017"
   }
 }


### PR DESCRIPTION
1. Recent PRs created some issues on Firefox, the Promise based `chrome.` APIs in Firefox/Safari must use `browser.` this is why we haven't usually used these in the past. But I want to be able to use this syntax, so I've added some global logic to magically use `browser.` when it's available (non-chromium browsers) and fallback to `chrome.` when it's not, this will allow the Promise based APIs to always work.
2. I also realized we're transpiling to polyfill async/await which we don't really need to, upped the target ES version in `.tsconfig`
3. `storage.getKeys()` JUST got added to Firefox https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/143#changes_for_add-on_developers so I'm changing things to use `storage.get(null)` instead since it has access to similar information
4. Changed to typedefinitions file to support the above and remove some legacy unnecessary definitions 