### PR TITLE
Maintain violations when tab ID is reused

### DIFF
--- a/src/js/background/historyManager.ts
+++ b/src/js/background/historyManager.ts
@@ -67,14 +67,19 @@ export async function upsertInvalidRecord(
   const tabIDKey = String(tabID);
   const entry = await chrome.storage.local.get(tabIDKey);
 
+  const violations = TAB_TO_VIOLATING_SRCS.get(tabID) ?? new Set();
+
   if (Object.keys(entry).length !== 0) {
     creationTime = entry[tabIDKey].creationTime;
+    entry[tabIDKey].violations.forEach((violation: Violation) => {
+      violations.add(violation);
+    });
   }
 
   return chrome.storage.local.set({
     [tabIDKey]: {
       creationTime,
-      violations: Array.from(TAB_TO_VIOLATING_SRCS.get(tabID) ?? new Set()),
+      violations: Array.from(violations),
       url: tab.url,
     },
   });


### PR DESCRIPTION
In Chrome tab ID would most likely be reused mostly on refresh, but Firefox tab Ids count upward from 1 so Ids are more likely to clash. In this case maintain the violations.