### PR TITLE
Verify inline scripts to account for nonce-* header usage

### DIFF
--- a/build/rollup-plugin-prettier-build-start.ts
+++ b/build/rollup-plugin-prettier-build-start.ts
@@ -34,7 +34,7 @@ export default function rollupPrettierBuildStartPlugin(files: string): Plugin {
       }
       console.log('Running prettier for', Array.from(filesToFormat).join(' '));
       await genExec(
-        `yarn run prettier ${Array.from(filesToFormat).join(' ')} --write`,
+        `yarn run prettier ${Array.from(filesToFormat).join(' ')} --check`,
       );
       filesToFormat.clear();
     },

--- a/src/js/__tests__/checkCSPForUnsafeInline-test.js
+++ b/src/js/__tests__/checkCSPForUnsafeInline-test.js
@@ -44,11 +44,11 @@ describe('checkCSPForUnsafeInline', () => {
     ]);
     expect(valid).toBeTruthy();
   });
-  it('Invalid due to unsafe-hashes in script-src', () => {
+  it('Valid despite unsafe-hashes in script-src', () => {
     const [valid] = checkCSPForUnsafeInline([
       `script-src 'self' 'unsafe-hashes' 'sha256-abc123';`,
     ]);
-    expect(valid).toBeFalsy();
+    expect(valid).toBeTruthy();
   });
   it('Valid despite nonce in default-src', () => {
     const [valid] = checkCSPForUnsafeInline([
@@ -56,16 +56,16 @@ describe('checkCSPForUnsafeInline', () => {
     ]);
     expect(valid).toBeTruthy();
   });
-  it('Invalid due to unsafe-hashes in default-src', () => {
+  it('Valid despite unsafe-hashes in default-src', () => {
     const [valid] = checkCSPForUnsafeInline([
       `default-src 'self' 'unsafe-hashes' 'sha256-xyz789';`,
     ]);
-    expect(valid).toBeFalsy();
+    expect(valid).toBeTruthy();
   });
-  it('Invalid due to nonce and unsafe-hashes combined', () => {
+  it('Valid despite nonce and unsafe-hashes combined', () => {
     const [valid] = checkCSPForUnsafeInline([
       `script-src 'self' 'nonce-abc123' 'unsafe-hashes' 'sha256-abc123';`,
     ]);
-    expect(valid).toBeFalsy();
+    expect(valid).toBeTruthy();
   });
 });

--- a/src/js/__tests__/checkCSPForUnsafeInline-test.js
+++ b/src/js/__tests__/checkCSPForUnsafeInline-test.js
@@ -38,4 +38,34 @@ describe('checkCSPForUnsafeInline', () => {
     ]);
     expect(valid).toBeFalsy();
   });
+  it('Valid despite nonce in script-src', () => {
+    const [valid] = checkCSPForUnsafeInline([
+      `script-src 'self' 'nonce-abc123';`,
+    ]);
+    expect(valid).toBeTruthy();
+  });
+  it('Invalid due to unsafe-hashes in script-src', () => {
+    const [valid] = checkCSPForUnsafeInline([
+      `script-src 'self' 'unsafe-hashes' 'sha256-abc123';`,
+    ]);
+    expect(valid).toBeFalsy();
+  });
+  it('Valid despite nonce in default-src', () => {
+    const [valid] = checkCSPForUnsafeInline([
+      `default-src 'self' 'nonce-xyz789';`,
+    ]);
+    expect(valid).toBeTruthy();
+  });
+  it('Invalid due to unsafe-hashes in default-src', () => {
+    const [valid] = checkCSPForUnsafeInline([
+      `default-src 'self' 'unsafe-hashes' 'sha256-xyz789';`,
+    ]);
+    expect(valid).toBeFalsy();
+  });
+  it('Invalid due to nonce and unsafe-hashes combined', () => {
+    const [valid] = checkCSPForUnsafeInline([
+      `script-src 'self' 'nonce-abc123' 'unsafe-hashes' 'sha256-abc123';`,
+    ]);
+    expect(valid).toBeFalsy();
+  });
 });

--- a/src/js/content.ts
+++ b/src/js/content.ts
@@ -274,11 +274,7 @@ function handleStyleNode(style: HTMLStyleElement): void {
 }
 
 function handleInlineScriptNode(script: HTMLScriptElement): void {
-  const versionAndOtherType = tryToGetManifestVersionAndTypeFromNode(script);
-  if (versionAndOtherType == null) {
-    return;
-  }
-  const [version, otherType] = versionAndOtherType;
+  const [version, otherType] = getManifestVersionAndTypeFromNode(script);
   ensureManifestWasOrWillBeLoaded(FOUND_MANIFEST_VERSIONS, version);
   pushToOrCreateArrayInMap(FOUND_ELEMENTS, version, {
     tag: script,

--- a/src/js/content.ts
+++ b/src/js/content.ts
@@ -76,6 +76,11 @@ export type TagDetails =
       otherType: string;
       tag: HTMLStyleElement;
       type: 'style';
+    }
+  | {
+      otherType: string;
+      tag: HTMLScriptElement;
+      type: 'inline_script';
     };
 let manifestTimeoutID: string | number = '';
 
@@ -268,6 +273,21 @@ function handleStyleNode(style: HTMLStyleElement): void {
   updateCurrentState(STATES.PROCESSING);
 }
 
+function handleInlineScriptNode(script: HTMLScriptElement): void {
+  const versionAndOtherType = tryToGetManifestVersionAndTypeFromNode(script);
+  if (versionAndOtherType == null) {
+    return;
+  }
+  const [version, otherType] = versionAndOtherType;
+  ensureManifestWasOrWillBeLoaded(FOUND_MANIFEST_VERSIONS, version);
+  pushToOrCreateArrayInMap(FOUND_ELEMENTS, version, {
+    tag: script,
+    otherType,
+    type: 'inline_script',
+  });
+  updateCurrentState(STATES.PROCESSING);
+}
+
 function handleLinkNode(link: HTMLLinkElement): void {
   const [version, otherType] = getManifestVersionAndTypeFromNode(link);
   ALL_FOUND_TAGS_URLS.add(link.href);
@@ -323,6 +343,8 @@ export function storeFoundElement(element: HTMLElement): void {
     }
     if (script.src !== '') {
       handleScriptNode(script);
+    } else if (script.innerHTML !== '') {
+      handleInlineScriptNode(script);
     }
   } else if (element.nodeName.toLowerCase() === 'style') {
     const style = element as HTMLStyleElement;

--- a/src/js/content/checkCSPForUnsafeInline.ts
+++ b/src/js/content/checkCSPForUnsafeInline.ts
@@ -7,8 +7,15 @@
 
 import {parseCSPString} from './parseCSPString';
 
+function rejectUnsafeHeaders(values: Set<string>): boolean {
+  if (values.has(`'unsafe-inline'`) || values.has(`'unsafe-hashes'`)) {
+    return false;
+  }
+  return true;
+}
+
 /**
- * Enforces that CSP headers do not allow unsafe-inline
+ * Enforces that CSP headers do not allow unsafe-inline or unsafe-hashes
  */
 export function checkCSPForUnsafeInline(
   cspHeaders: Array<string>,
@@ -18,12 +25,12 @@ export function checkCSPForUnsafeInline(
 
     const scriptSrc = headers.get('script-src');
     if (scriptSrc) {
-      return !scriptSrc.has(`'unsafe-inline'`);
+      return rejectUnsafeHeaders(scriptSrc);
     }
 
     const defaultSrc = headers.get('default-src');
     if (defaultSrc) {
-      return !defaultSrc.has(`'unsafe-inline'`);
+      return rejectUnsafeHeaders(defaultSrc);
     }
 
     return false;
@@ -32,6 +39,9 @@ export function checkCSPForUnsafeInline(
   if (preventsUnsafeInline) {
     return [true];
   } else {
-    return [false, 'CSP Headers do not prevent unsafe-inline.'];
+    return [
+      false,
+      'CSP Headers do not prevent unsafe-inline or unsafe-hashes.',
+    ];
   }
 }

--- a/src/js/content/checkCSPForUnsafeInline.ts
+++ b/src/js/content/checkCSPForUnsafeInline.ts
@@ -8,14 +8,14 @@
 import {parseCSPString} from './parseCSPString';
 
 function rejectUnsafeHeaders(values: Set<string>): boolean {
-  if (values.has(`'unsafe-inline'`) || values.has(`'unsafe-hashes'`)) {
+  if (values.has(`'unsafe-inline'`)) {
     return false;
   }
   return true;
 }
 
 /**
- * Enforces that CSP headers do not allow unsafe-inline or unsafe-hashes
+ * Enforces that CSP headers do not allow unsafe-inline
  */
 export function checkCSPForUnsafeInline(
   cspHeaders: Array<string>,
@@ -39,9 +39,6 @@ export function checkCSPForUnsafeInline(
   if (preventsUnsafeInline) {
     return [true];
   } else {
-    return [
-      false,
-      'CSP Headers do not prevent unsafe-inline or unsafe-hashes.',
-    ];
+    return [false, 'CSP Headers do not prevent unsafe-inline.'];
   }
 }

--- a/src/js/content/contentUtils.ts
+++ b/src/js/content/contentUtils.ts
@@ -51,7 +51,7 @@ async function processSrc(
 
       // split package up if necessary
       packages = sourceText.split('/*FB_PKG_DELIM*/\n');
-    } else if (tagDetails.type === 'style') {
+    } else if (tagDetails.type === 'style' || tagDetails.type === 'inline_script') {
       packages = [tagDetails.tag.innerHTML];
     }
 

--- a/src/js/content/contentUtils.ts
+++ b/src/js/content/contentUtils.ts
@@ -51,7 +51,10 @@ async function processSrc(
 
       // split package up if necessary
       packages = sourceText.split('/*FB_PKG_DELIM*/\n');
-    } else if (tagDetails.type === 'style' || tagDetails.type === 'inline_script') {
+    } else if (
+      tagDetails.type === 'style' ||
+      tagDetails.type === 'inline_script'
+    ) {
       packages = [tagDetails.tag.innerHTML];
     }
 

--- a/src/js/content/getTagIdentifier.ts
+++ b/src/js/content/getTagIdentifier.ts
@@ -15,5 +15,7 @@ export function getTagIdentifier(tagDetails: TagDetails): string {
       return tagDetails.href;
     case 'style':
       return 'style_' + tagDetails.tag.innerHTML.substring(0, 100);
+    case 'inline_script':
+      return 'inline_script_' + tagDetails.tag.innerHTML.substring(0, 100);
   }
 }


### PR DESCRIPTION
## Problem

Inline scripts can be evaluated by the browser when CSP allows `nonce-*` headers, so we cannot skip content verification even if `unsafe-inline` is not present.

## This change

* Adds back content verification on inline scripts
* Updates tests