### PR TITLE
Match Vary: Service-Worker response header case-insensitively

### DIFF
--- a/src/js/__tests__/hasVaryServiceWorkerHeader-test.js
+++ b/src/js/__tests__/hasVaryServiceWorkerHeader-test.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import {hasVaryServiceWorkerHeader} from '../content/hasVaryServiceWorkerHeader';
+
+describe('hasVaryServiceWorkerHeader', () => {
+  it('detects a lowercase vary header', () => {
+    expect(
+      hasVaryServiceWorkerHeader({
+        responseHeaders: [{name: 'vary', value: 'Service-Worker'}],
+      }),
+    ).toBe(true);
+  });
+
+  it('detects the canonical capitalized Vary header', () => {
+    // HTTP header names are case-insensitive and servers send `Vary`
+    // capitalized in practice.
+    expect(
+      hasVaryServiceWorkerHeader({
+        responseHeaders: [{name: 'Vary', value: 'Service-Worker'}],
+      }),
+    ).toBe(true);
+  });
+
+  it('detects a lowercase service-worker token in the Vary value', () => {
+    // Vary lists request header names, which are also case-insensitive.
+    expect(
+      hasVaryServiceWorkerHeader({
+        responseHeaders: [{name: 'Vary', value: 'Accept, service-worker'}],
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false when no Vary: Service-Worker header is present', () => {
+    expect(
+      hasVaryServiceWorkerHeader({
+        responseHeaders: [
+          {name: 'Vary', value: 'Accept-Encoding'},
+          {name: 'Content-Type', value: 'text/javascript'},
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when there are no response headers', () => {
+    expect(hasVaryServiceWorkerHeader({})).toBe(false);
+  });
+});

--- a/src/js/content/hasVaryServiceWorkerHeader.ts
+++ b/src/js/content/hasVaryServiceWorkerHeader.ts
@@ -11,8 +11,10 @@ export function hasVaryServiceWorkerHeader(
   return (
     response.responseHeaders?.find(
       header =>
-        header.name.includes('vary') &&
-        header.value?.includes('Service-Worker'),
+        // HTTP header names are case-insensitive, and the field names listed
+        // in a Vary value are too, so normalize before matching.
+        header.name.toLowerCase().includes('vary') &&
+        header.value?.toLowerCase().includes('service-worker'),
     ) !== undefined
   );
 }


### PR DESCRIPTION
## Summary

`hasVaryServiceWorkerHeader` compared the response header **name** against the lowercase literal `'vary'` and the **value** against `'Service-Worker'`, both case-sensitively:

```ts
header.name.includes('vary') &&
header.value?.includes('Service-Worker')
```

HTTP header names are case-insensitive, and servers send the canonical `Vary` header capitalized. As a result a perfectly valid `Vary: Service-Worker` response header was **not** detected. The field names listed in a `Vary` value are header names too, so they are likewise case-insensitive.

This is the only place in the codebase where a response header name is compared without first lowercasing it — compare `getCSPHeadersFromWebRequestResponse` (`header.name.toLowerCase() === 'content-security-policy'`) and `setUpWebRequestsListener` (`header.name.toLowerCase().includes('x-content-type-options')`).

Downstream, `isServiceWorker` (content.ts) is derived from this check and controls whether the `Service-Worker: script` request header is sent when re-fetching, so a miss here can fetch the wrong resource variant.

## Fix

Normalize both name and value to lower case before matching.

## Test plan

Added `src/js/__tests__/hasVaryServiceWorkerHeader-test.js` covering lowercase `vary`, the canonical capitalized `Vary`, a lowercase `service-worker` token in the value, the negative case, and missing response headers. Verified failing before the fix (capitalized-name and lowercase-value cases) and passing after.

Full suite: `11 passed, 97 tests passed` (was 92), no regressions.