### PR TITLE
Split CSP policy lists on a bare comma, not just ", "

### DIFF
--- a/src/js/__tests__/getCSPHeadersFromWebRequestResponse-test.js
+++ b/src/js/__tests__/getCSPHeadersFromWebRequestResponse-test.js
@@ -94,4 +94,21 @@ describe('getCSPHeadersFromWebRequestResponse', () => {
       },
     ]);
   });
+  it('Splits a policy list separated by a comma with no space', () => {
+    // https://www.w3.org/TR/CSP3/#parse-serialized-policy-list splits the
+    // serialized policy list on U+002C COMMA, the space is not required.
+    expect(
+      getCSPHeadersFromWebRequestResponse({
+        responseHeaders: [
+          {
+            name: KEY,
+            value: "default-src 'self';,script-src 'self';",
+          },
+        ],
+      }),
+    ).toEqual([
+      {name: KEY, value: "default-src 'self';"},
+      {name: KEY, value: "script-src 'self';"},
+    ]);
+  });
 });

--- a/src/js/shared/getCSPHeadersFromWebRequestResponse.ts
+++ b/src/js/shared/getCSPHeadersFromWebRequestResponse.ts
@@ -21,17 +21,21 @@ export function getCSPHeadersFromWebRequestResponse(
         : 'content-security-policy'),
   );
 
-  // A single header value can be a comma seperated list of headers
+  // A single header value can be a comma separated list of policies. The
+  // separator is a bare comma; the surrounding whitespace is optional.
   // https://www.w3.org/TR/CSP3/#parse-serialized-policy-list
   const individualHeaders: Array<chrome.webRequest.HttpHeader> = [];
   cspHeaders.forEach(header => {
-    if (header.value?.includes(', ')) {
-      header.value.split(', ').forEach(headerValue => {
-        individualHeaders.push({name: header.name, value: headerValue});
-      });
-    } else {
+    if (header.value == null) {
       individualHeaders.push(header);
+      return;
     }
+    header.value.split(',').forEach(headerValue => {
+      const trimmed = headerValue.trim();
+      if (trimmed !== '') {
+        individualHeaders.push({name: header.name, value: trimmed});
+      }
+    });
   });
   return individualHeaders;
 }


### PR DESCRIPTION
## Summary

`getCSPHeadersFromWebRequestResponse` splits a combined CSP header into individual policies only when the value contains `', '` (comma **+ space**):

```ts
if (header.value?.includes(', ')) {
  header.value.split(', ').forEach(/* ... */);
} else {
  individualHeaders.push(header);
}
```

Per [CSP3 §parse a serialized CSP list](https://www.w3.org/TR/CSP3/#parse-serialized-policy-list) the separator is a bare `U+002C COMMA`; the surrounding whitespace is optional. So a server sending

```
Content-Security-Policy: default-src 'self';,script-src 'self';
```

is left as a single combined string. `parseCSPString` then splits it on `;`, yielding a `,script-src` directive token with a stray leading comma that never matches `script-src`. The `script-src` policy is silently dropped, which weakens the eval/worker CSP checks that depend on detecting it — a correctness gap in a security extension.

## Fix

Split on `,` and `trim()` each policy (dropping empty entries). Inputs using the conventional `', '` separator produce identical output, so this is backwards compatible.

## Test plan

Added a regression test for a policy list separated by a comma with no space. Verified it fails before the change and passes after.

- Full suite: `11 passed, 98 tests passed` (was 97), no regressions.
- Prettier clean.