### PR TITLE
Fix typos in manifest error message and CSS inspector

### DIFF
--- a/src/js/content.ts
+++ b/src/js/content.ts
@@ -42,7 +42,7 @@ import {
   getManifestVersionAndTypeFromNode,
   tryToGetManifestVersionAndTypeFromNode,
 } from './content/getManifestVersionAndTypeFromNode';
-import {scanForCSSNeedingManualInspsection} from './content/manualCSSInspector';
+import {scanForCSSNeedingManualInspection} from './content/manualCSSInspector';
 
 type ContentScriptConfig = {
   checkLoggedInFromCookie: boolean;
@@ -461,7 +461,7 @@ export function startFor(origin: Origin, config: ContentScriptConfig): void {
   if (isUserLoggedIn) {
     updateCurrentState(STATES.PROCESSING);
     scanForScriptsAndStyles();
-    scanForCSSNeedingManualInspsection();
+    scanForCSSNeedingManualInspection();
     // set the timeout once, in case there's an iframe and contentUtils sets another manifest timer
     if (manifestTimeoutID === '') {
       manifestTimeoutID = window.setTimeout(() => {

--- a/src/js/content/getManifestVersionAndTypeFromNode.ts
+++ b/src/js/content/getManifestVersionAndTypeFromNode.ts
@@ -16,7 +16,7 @@ export function getManifestVersionAndTypeFromNode(
 
   if (!versionAndType) {
     invalidateAndThrow(
-      `Missing manifest data attribute or invalid version/typeon attribute`,
+      `Missing manifest data attribute or invalid version/type on attribute`,
     );
   }
 

--- a/src/js/content/manualCSSInspector.ts
+++ b/src/js/content/manualCSSInspector.ts
@@ -11,7 +11,7 @@ import {updateCurrentState} from './updateCurrentState';
 
 const CHECKED_STYLESHEET_HASHES = new Set<string>();
 
-export function scanForCSSNeedingManualInspsection(): void {
+export function scanForCSSNeedingManualInspection(): void {
   checkForStylesheetChanges();
   setInterval(checkForStylesheetChanges, 1000);
 }
@@ -22,7 +22,7 @@ async function checkForStylesheetChanges() {
       const potentialOwnerNode = sheet.ownerNode;
 
       if (sheet.href && potentialOwnerNode instanceof HTMLLinkElement) {
-        // Link style tags are checked agains the manifest
+        // Link style tags are checked against the manifest
         return;
       }
 


### PR DESCRIPTION
## Summary

Small typo/readability cleanup:

- **User-facing error message**: `getManifestVersionAndTypeFromNode` threw `Missing manifest data attribute or invalid version/typeon attribute` — `typeon` should read `type on`.
- **Misspelled function name**: `scanForCSSNeedingManualInspsection` → `scanForCSSNeedingManualInspection`. It is internal (defined in `manualCSSInspector.ts`, imported and called once in `content.ts`); all three sites are updated.
- **Comment**: `Link style tags are checked agains the manifest` → `against`.

No behavior change.

## Test plan

`node --experimental-vm-modules ... jest --watchman=false`: **10 suites, 92 tests pass**, no regressions. Prettier clean.