### PR TITLE
Add CSP checks for script-src-attr and script-src-elem

### DIFF
--- a/src/js/__tests__/checkCSPForScriptSrcAttr-test.js
+++ b/src/js/__tests__/checkCSPForScriptSrcAttr-test.js
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import {jest} from '@jest/globals';
+import {checkDocumentCSPHeaders} from '../content/checkDocumentCSPHeaders';
+import {checkCSPForScriptSrcAttr} from '../content/checkCSPForScriptSrcAttr';
+import {ORIGIN_TYPE} from '../config';
+import {setCurrentOrigin} from '../content/updateCurrentState';
+
+describe('checkCSPForScriptSrcAttr', () => {
+  it('allows an explicit script-src-attr none policy', () => {
+    const [valid] = checkCSPForScriptSrcAttr([
+      `script-src 'unsafe-inline'; script-src-attr 'none';`,
+    ]);
+    expect(valid).toBeTruthy();
+  });
+
+  it('rejects unsafe-inline in script-src-attr', () => {
+    const [valid] = checkCSPForScriptSrcAttr([
+      `script-src 'self'; script-src-attr 'unsafe-inline';`,
+    ]);
+    expect(valid).toBeFalsy();
+  });
+
+  it('rejects unsafe-hashes with a hash source in script-src-attr', () => {
+    const [valid] = checkCSPForScriptSrcAttr([
+      `script-src-attr 'unsafe-hashes' 'sha256-abc123';`,
+    ]);
+    expect(valid).toBeFalsy();
+  });
+
+  it('allows unsafe-hashes without a hash source', () => {
+    const [valid] = checkCSPForScriptSrcAttr([
+      `script-src-attr 'unsafe-hashes';`,
+    ]);
+    expect(valid).toBeTruthy();
+  });
+
+  it('allows a hash source without unsafe-hashes', () => {
+    const [valid] = checkCSPForScriptSrcAttr([
+      `script-src-attr 'sha256-abc123';`,
+    ]);
+    expect(valid).toBeTruthy();
+  });
+
+  it('falls back to a safe script-src policy', () => {
+    const [valid] = checkCSPForScriptSrcAttr([`script-src 'self';`]);
+    expect(valid).toBeTruthy();
+  });
+
+  it('rejects unsafe-inline from the script-src fallback', () => {
+    const [valid] = checkCSPForScriptSrcAttr([
+      `script-src 'self' 'unsafe-inline';`,
+    ]);
+    expect(valid).toBeFalsy();
+  });
+
+  it('falls back to a safe default-src policy', () => {
+    const [valid] = checkCSPForScriptSrcAttr([`default-src 'self';`]);
+    expect(valid).toBeTruthy();
+  });
+
+  it('rejects unsafe hashes from the default-src fallback', () => {
+    const [valid] = checkCSPForScriptSrcAttr([
+      `default-src 'unsafe-hashes' 'sha512-def456';`,
+    ]);
+    expect(valid).toBeFalsy();
+  });
+
+  it('rejects a policy without a script attribute source list', () => {
+    const [valid] = checkCSPForScriptSrcAttr([`worker-src example.com;`]);
+    expect(valid).toBeFalsy();
+  });
+
+  it('accepts multiple policies when one blocks script attributes', () => {
+    const [valid] = checkCSPForScriptSrcAttr([
+      `script-src-attr 'unsafe-inline';`,
+      `script-src-attr 'none';`,
+    ]);
+    expect(valid).toBeTruthy();
+  });
+
+  it('does not use script-src-elem for event-handler attributes', () => {
+    const [valid] = checkCSPForScriptSrcAttr([
+      `script-src 'self'; script-src-elem 'unsafe-inline';`,
+    ]);
+    expect(valid).toBeTruthy();
+  });
+
+  it('handles directive and source keywords case-insensitively', () => {
+    const [valid] = checkCSPForScriptSrcAttr([
+      `sCrIpT-sRc-AtTr 'UNSAFE-INLINE';`,
+    ]);
+    expect(valid).toBeFalsy();
+  });
+});
+
+describe('checkDocumentCSPHeaders', () => {
+  beforeEach(() => {
+    window.chrome.runtime.sendMessage = jest.fn(() => {});
+    setCurrentOrigin(ORIGIN_TYPE.FACEBOOK);
+  });
+
+  it('invalidates a document that allows inline event handlers', () => {
+    expect(() =>
+      checkDocumentCSPHeaders(
+        [
+          `script-src 'self';` +
+            `script-src-attr 'unsafe-inline';` +
+            `worker-src https://workers.example/worker.js;`,
+        ],
+        [],
+        ORIGIN_TYPE.FACEBOOK,
+      ),
+    ).toThrow('CSP Headers allow unverified script attributes.');
+  });
+});

--- a/src/js/__tests__/checkCSPForUnsafeInline-test.js
+++ b/src/js/__tests__/checkCSPForUnsafeInline-test.js
@@ -28,6 +28,18 @@ describe('checkCSPForUnsafeInline', () => {
     ]);
     expect(valid).toBeFalsy();
   });
+  it('Valid when script-src-elem overrides an unsafe script-src', () => {
+    const [valid] = checkCSPForUnsafeInline([
+      `script-src 'unsafe-inline'; script-src-elem 'self';`,
+    ]);
+    expect(valid).toBeTruthy();
+  });
+  it('Invalid when script-src-elem overrides a safe script-src', () => {
+    const [valid] = checkCSPForUnsafeInline([
+      `script-src 'self'; script-src-elem 'unsafe-inline';`,
+    ]);
+    expect(valid).toBeFalsy();
+  });
   it('Valid due to default-src', () => {
     const [valid] = checkCSPForUnsafeInline([`default-src 'self';`]);
     expect(valid).toBeTruthy();

--- a/src/js/content/checkCSPForScriptSrcAttr.ts
+++ b/src/js/content/checkCSPForScriptSrcAttr.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {parseCSPString} from './parseCSPString';
+
+function isHashSource(value: string): boolean {
+  return /^'sha(?:256|384|512)-/.test(value);
+}
+
+function allowsUnverifiedScriptAttributes(values: Set<string>): boolean {
+  if (values.has(`'unsafe-inline'`)) {
+    return true;
+  }
+
+  return (
+    values.has(`'unsafe-hashes'`) &&
+    // N.B. unsafe-hashes is technically benign when no an actual hash specified
+    Array.from(values.values()).some(isHashSource)
+  );
+}
+
+/**
+ * Enforces that inline event-handler attributes cannot execute unverified
+ * JavaScript. script-src-attr falls back to script-src, then default-src.
+ */
+export function checkCSPForScriptSrcAttr(
+  cspHeaders: Array<string>,
+): [true] | [false, string] {
+  // Multiple enforced CSP policies are intersected by the browser, so one
+  // policy that blocks script attributes is sufficient.
+  const preventsUnverifiedScriptAttributes = cspHeaders.some(cspHeader => {
+    const headers = parseCSPString(cspHeader);
+    const effectiveScriptAttrSources =
+      headers.get('script-src-attr') ??
+      headers.get('script-src') ??
+      headers.get('default-src');
+
+    return (
+      effectiveScriptAttrSources != null &&
+      !allowsUnverifiedScriptAttributes(effectiveScriptAttrSources)
+    );
+  });
+
+  if (preventsUnverifiedScriptAttributes) {
+    return [true];
+  } else {
+    return [false, 'CSP Headers allow unverified script attributes.'];
+  }
+}

--- a/src/js/content/checkCSPForUnsafeInline.ts
+++ b/src/js/content/checkCSPForUnsafeInline.ts
@@ -15,25 +15,23 @@ function rejectUnsafeHeaders(values: Set<string>): boolean {
 }
 
 /**
- * Enforces that CSP headers do not allow unsafe-inline
+ * Enforces that CSP headers do not allow unsafe-inline script elements.
+ * script-src-elem falls back to script-src, then default-src.
  */
 export function checkCSPForUnsafeInline(
   cspHeaders: Array<string>,
 ): [true] | [false, string] {
   const preventsUnsafeInline = cspHeaders.some(cspHeader => {
     const headers = parseCSPString(cspHeader);
+    const effectiveScriptSources =
+      headers.get('script-src-elem') ??
+      headers.get('script-src') ??
+      headers.get('default-src');
 
-    const scriptSrc = headers.get('script-src');
-    if (scriptSrc) {
-      return rejectUnsafeHeaders(scriptSrc);
-    }
-
-    const defaultSrc = headers.get('default-src');
-    if (defaultSrc) {
-      return rejectUnsafeHeaders(defaultSrc);
-    }
-
-    return false;
+    return (
+      effectiveScriptSources != null &&
+      rejectUnsafeHeaders(effectiveScriptSources)
+    );
   });
 
   if (preventsUnsafeInline) {

--- a/src/js/content/checkDocumentCSPHeaders.ts
+++ b/src/js/content/checkDocumentCSPHeaders.ts
@@ -9,6 +9,7 @@ import {Origin, ORIGIN_HOST} from '../config';
 import {invalidateAndThrow} from './updateCurrentState';
 import {parseCSPString} from './parseCSPString';
 import {checkCSPForEvals} from './checkCSPForEvals';
+import {checkCSPForScriptSrcAttr} from './checkCSPForScriptSrcAttr';
 import {checkCSPForUnsafeInline} from './checkCSPForUnsafeInline';
 
 export function checkCSPForWorkerSrc(
@@ -63,6 +64,7 @@ export function checkDocumentCSPHeaders(
 ): void {
   [
     checkCSPForUnsafeInline(cspHeaders),
+    checkCSPForScriptSrcAttr(cspHeaders),
     checkCSPForEvals(cspHeaders, cspReportHeaders),
     checkCSPForWorkerSrc(cspHeaders, origin),
   ].forEach(([valid, reason]) => {


### PR DESCRIPTION
## Summary

`script-src-elem` and `script-src-attr` are two specific attributes for the overall `script-src` attribute. One controls script element execution sources, and the other controls element inline event handlers (e.g. `<img src="bad-url" onerror="payload()">`). This PR adds in checks for both to the extension.

For `script-src-elem`, the existing `script-src` check was modified. `script-src-attr` a new check was added in, since we need check for both `'unsafe-inline'`, as well as `'unsafe-hashes'` with a hash value. Because `script-src-attr` fallbacks to `script-src` and `default-src` when missing, the new checker needs to inspect those as well. This sort of makes the `'unsafe-inline'` check redundant for now - I'll look into refactoring that later in the future...

## Tests

- Ran extension test suite
- Loaded FB, IG and WA as a smoke test and ensured extension reported green
- Modified CSP for FB to different kinds of disallowed `script-src-elem` and `script-src-attr` attributes, and ensured extension reported red for those due to CSP violations.