### PR TITLE
Fix manifest JSON parse retries

### DIFF
--- a/src/js/__tests__/content-test.js
+++ b/src/js/__tests__/content-test.js
@@ -54,6 +54,37 @@ describe('content', () => {
       expect(window.chrome.runtime.sendMessage.mock.calls.length).toBe(1);
       expect(sentMessage.type).toEqual(MESSAGE_TYPE.UPDATE_STATE);
     });
+    it('should process a manifest after its JSON becomes available', () => {
+      jest.useFakeTimers();
+      const manifestNode = document.createElement('script');
+      manifestNode.id = 'binary-transparency-manifest';
+      manifestNode.type = 'application/json';
+      manifestNode.setAttribute('data-manifest-type', 'main');
+      manifestNode.setAttribute('data-manifest-rev', '123');
+
+      storeFoundElement(manifestNode);
+      manifestNode.textContent = JSON.stringify({
+        manifest: [],
+        manifest_hashes: {
+          combined_hash: 'combined-hash',
+          longtail: 'longtail-hash',
+          main: 'main-hash',
+        },
+        leaves: [],
+        root: 'root-hash',
+        version: '123',
+      });
+      jest.advanceTimersByTime(20);
+
+      expect(window.chrome.runtime.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MESSAGE_TYPE.LOAD_COMPANY_MANIFEST,
+          version: '123',
+        }),
+        expect.any(Function),
+      );
+      jest.useRealTimers();
+    });
     it.skip('storeFoundElement keeps existing icon if not valid', () => {
       // TODO: come back to this after testing processFoundJS
     });

--- a/src/js/__tests__/parseFailedJSON-test.js
+++ b/src/js/__tests__/parseFailedJSON-test.js
@@ -23,17 +23,24 @@ describe('parseFailedJSON', () => {
     clearFailedForTestDoNotUse();
   });
   it('Should correctly parse valid JSON', () => {
-    parseFailedJSON({
-      node: {textContent: '{}'},
-      retry: 10,
-    });
+    const onSuccess = jest.fn();
+    parseFailedJSON({textContent: '{}'}, 10, onSuccess);
     expect(getFailedForTestDoNotUse()).toBe(null);
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+  it('Should not retry when the success callback throws', () => {
+    const onSuccess = jest.fn(() => {
+      throw new Error('Callback failed');
+    });
+
+    expect(() => parseFailedJSON({textContent: '{}'}, 10, onSuccess)).toThrow(
+      'Callback failed',
+    );
+    jest.runAllTimers();
+    expect(onSuccess).toHaveBeenCalledTimes(1);
   });
   it('Should throw on invalid JSON', () => {
-    parseFailedJSON({
-      node: {textContent: ''},
-      retry: 10,
-    });
+    parseFailedJSON({textContent: ''}, 10);
     setTimeout(() => {
       expect(getFailedForTestDoNotUse()).toBe(true);
     }, 500);
@@ -41,13 +48,15 @@ describe('parseFailedJSON', () => {
   });
   it('Should eventually success', () => {
     const node = {textContent: ''};
-    parseFailedJSON({node, retry: 50});
+    const onSuccess = jest.fn();
+    parseFailedJSON(node, 50, onSuccess);
     setTimeout(() => {
       node.textContent = '{}';
     }, 200);
     jest.runAllTimers();
     setTimeout(() => {
       expect(getFailedForTestDoNotUse()).toBe(null);
+      expect(onSuccess).toHaveBeenCalledTimes(1);
     }, 200);
     jest.runAllTimers();
   });

--- a/src/js/content.ts
+++ b/src/js/content.ts
@@ -109,7 +109,7 @@ function handleManifestNode(manifestNode: HTMLScriptElement): void {
   try {
     rawManifest = JSON.parse(manifestNodeTextContent);
   } catch {
-    setTimeout(() => parseFailedJSON({node: manifestNode, retry: 5000}), 20);
+    parseFailedJSON(manifestNode, 5000, () => handleManifestNode(manifestNode));
     return;
   }
 
@@ -313,6 +313,7 @@ export function storeFoundElement(element: HTMLElement): void {
       element.getAttribute('name') === 'binary-transparency-manifest')
   ) {
     handleManifestNode(element as HTMLScriptElement);
+    return;
   }
 
   // Only a document/doctype can have textContent as null
@@ -321,7 +322,7 @@ export function storeFoundElement(element: HTMLElement): void {
     try {
       JSON.parse(nodeTextContent);
     } catch {
-      setTimeout(() => parseFailedJSON({node: element, retry: 1500}), 20);
+      parseFailedJSON(element, 1500);
     }
     return;
   }

--- a/src/js/content/parseFailedJSON.ts
+++ b/src/js/content/parseFailedJSON.ts
@@ -19,21 +19,23 @@ export function getFailedForTestDoNotUse(): boolean | null {
   return failed_FOR_TEST_DO_NOT_USE;
 }
 
-export function parseFailedJSON(queuedJsonToParse: {
-  node: Element;
-  retry: number;
-}): void {
+export function parseFailedJSON(
+  node: Element,
+  retry: number,
+  onSuccess?: () => void,
+): void {
   // Only a document/doctype can have textContent as null
-  const nodeTextContent = queuedJsonToParse.node.textContent ?? '';
+  const nodeTextContent = node.textContent ?? '';
   try {
     JSON.parse(nodeTextContent);
   } catch {
-    if (queuedJsonToParse.retry > 0) {
-      queuedJsonToParse.retry--;
-      setTimeout(() => parseFailedJSON(queuedJsonToParse), 20);
+    if (retry > 0) {
+      setTimeout(() => parseFailedJSON(node, retry - 1, onSuccess), 20);
     } else {
       updateCurrentState(STATES.INVALID);
       failed_FOR_TEST_DO_NOT_USE = true;
     }
+    return;
   }
+  onSuccess?.();
 }


### PR DESCRIPTION
## Summary

There's currently a bug where manifest nodes that fail to parse (due to partial loading and browser parsing of the node), don't ever end up getting retried. This fixes that by reprocessing the manifest after parsing succeeds so it is not forgotten

## Test plan

- Ran test suite
- Loaded extension on browser and ensured facebook.com passed as a smoke test