### PR TITLE
Improve handling empty frames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 CLAUDE.local.md
 .codex/worktrees
 AGENTS.override.md
+.llms
 
 # Node Managers
 .node-version

--- a/src/js/__tests__/content-test.js
+++ b/src/js/__tests__/content-test.js
@@ -8,6 +8,7 @@
 'use strict';
 
 import {jest} from '@jest/globals';
+import {STATES} from '../config';
 import {MESSAGE_TYPE} from '../shared/sendMessageToBackground';
 import {
   hasInvalidScriptsOrStyles,
@@ -103,17 +104,19 @@ describe('content', () => {
       const element = createInlineScript('queued script');
       FOUND_ELEMENTS.set('123', [element]);
 
-      await processFoundElementsForVersion('123');
+      const didFinishProcessing = await processFoundElementsForVersion('123');
 
+      expect(didFinishProcessing).toBe(false);
       expect(FOUND_ELEMENTS.get('123')).toEqual([element]);
       expect(window.chrome.runtime.sendMessage).not.toHaveBeenCalled();
     });
 
-    it('does nothing when a loaded manifest has no elements', async () => {
+    it('finishes processing when a loaded manifest has no elements', async () => {
       FOUND_MANIFEST_VERSIONS.add('123');
 
-      await processFoundElementsForVersion('123');
+      const didFinishProcessing = await processFoundElementsForVersion('123');
 
+      expect(didFinishProcessing).toBe(true);
       expect(window.chrome.runtime.sendMessage).not.toHaveBeenCalled();
     });
 
@@ -126,11 +129,12 @@ describe('content', () => {
       FOUND_MANIFEST_VERSIONS.add('123');
       FOUND_MANIFEST_VERSIONS.add('456');
 
-      await Promise.all([
+      const processingResults = await Promise.all([
         processFoundElementsForVersion('123'),
         processFoundElementsForVersion('456'),
       ]);
 
+      expect(processingResults).toEqual([true, true]);
       expect(FOUND_ELEMENTS.get('123')).toEqual([]);
       expect(FOUND_ELEMENTS.get('456')).toEqual([]);
       const rawSourceMessages = window.chrome.runtime.sendMessage.mock.calls
@@ -141,6 +145,13 @@ describe('content', () => {
         '123',
         '456',
       ]);
+      expect(
+        window.chrome.runtime.sendMessage.mock.calls.some(
+          ([message]) =>
+            message.type === MESSAGE_TYPE.UPDATE_STATE &&
+            message.state === STATES.VALID,
+        ),
+      ).toBe(false);
     });
   });
   describe('hasInvalidScriptsOrStyles', () => {

--- a/src/js/content.ts
+++ b/src/js/content.ts
@@ -32,7 +32,11 @@ import {pushToOrCreateArrayInMap} from './shared/nestedDataHelpers';
 import {asyncThrottle} from './shared/asyncThrottle';
 import {downloadSrc, processSrc} from './content/sourceUtils';
 import {hasVaryServiceWorkerHeader} from './content/hasVaryServiceWorkerHeader';
-import {isSameDomainAsTopWindow, isTopWindow} from './content/iFrameUtils';
+import {
+  isBlankChildFrame,
+  isSameDomainAsTopWindow,
+  isTopWindow,
+} from './content/iFrameUtils';
 import {getTagIdentifier} from './content/getTagIdentifier';
 import {
   BOTH,
@@ -203,17 +207,18 @@ async function handleManifestNode(
   }
 }
 
+function hasOwnManifest(): boolean {
+  return isTopWindow() || (!isSameDomainAsTopWindow() && !isBlankChildFrame());
+}
+
 export async function processFoundElementsForVersion(
   version: string,
-): Promise<void> {
+): Promise<boolean> {
   // See if we have the manifest yet; Top-level window and X-Origin frames have
   // their own manifest. Same-orgin frames rely on their parent window's
   // manifest, so a missing manifest there is normal/expected.
-  if (
-    !FOUND_MANIFEST_VERSIONS.has(version) &&
-    (isTopWindow() || !isSameDomainAsTopWindow())
-  ) {
-    return;
+  if (!FOUND_MANIFEST_VERSIONS.has(version) && hasOwnManifest()) {
+    return false;
   }
 
   const elementsForVersion = FOUND_ELEMENTS.get(version) ?? [];
@@ -227,17 +232,13 @@ export async function processFoundElementsForVersion(
       elementsForVersion.push(element);
     }
   });
-  let pendingElementCount = elements.length;
+  let allElementsAreValid = true;
   for (const element of elements) {
     const response = await processSrc(element, version);
     const tagIdentifier = getTagIdentifier(element);
 
-    pendingElementCount--;
-    if (response.valid) {
-      if (pendingElementCount == 0) {
-        updateCurrentState(STATES.VALID);
-      }
-    } else {
+    if (!response.valid) {
+      allElementsAreValid = false;
       updateCurrentState(STATES.INVALID, `Invalid Tag ${tagIdentifier}`);
     }
     sendMessageToBackground({
@@ -248,14 +249,31 @@ export async function processFoundElementsForVersion(
       src: tagIdentifier,
     });
   }
+
+  return allElementsAreValid;
 }
 
 export const processFoundElements = asyncThrottle(async (): Promise<void> => {
-  await Promise.all(
+  const noElementsArePending = (): boolean =>
+    Array.from(FOUND_ELEMENTS.values()).every(
+      elements => elements.length === 0,
+    );
+
+  // We're not waiting on a manifest, and we don't have any tags to check
+  if (!hasOwnManifest() && noElementsArePending()) {
+    updateCurrentState(STATES.VALID);
+    return;
+  }
+
+  const processingResults = await Promise.all(
     Array.from(FOUND_ELEMENTS.keys(), version =>
       processFoundElementsForVersion(version),
     ),
   );
+
+  if (processingResults.every(Boolean) && noElementsArePending()) {
+    updateCurrentState(STATES.VALID);
+  }
 }, 3000);
 
 function addFoundElement(version: string, element: TagDetails): void {
@@ -315,17 +333,9 @@ function handleLinkNode(link: HTMLLinkElement): void {
 }
 
 export function storeFoundElement(element: HTMLElement): void {
-  // Same-origin iframes use the manifest processed in the top-level frame.
-  if (!isTopWindow() && isSameDomainAsTopWindow()) {
-    if (manifestTimeoutID != null) {
-      clearTimeout(manifestTimeoutID);
-      manifestTimeoutID = null;
-    }
-  }
-
   // check if it's the manifest node
   if (
-    (isTopWindow() || !isSameDomainAsTopWindow()) &&
+    hasOwnManifest() &&
     (element.id === 'binary-transparency-manifest' ||
       element.getAttribute('name') === 'binary-transparency-manifest')
   ) {
@@ -484,12 +494,13 @@ export async function startFor(
     updateCurrentState(STATES.PROCESSING);
     scanForScriptsAndStyles();
     scanForCSSNeedingManualInspection();
-    if (manifestTimeoutID == null) {
+    if (hasOwnManifest() && manifestTimeoutID == null) {
       manifestTimeoutID = window.setTimeout(() => {
         // Manifest failed to load, flag a warning to the user.
         updateCurrentState(STATES.TIMEOUT);
       }, MANIFEST_TIMEOUT);
     }
+    processFoundElements();
   }
 }
 

--- a/src/js/content/checkWorkerEndpointCSP.ts
+++ b/src/js/content/checkWorkerEndpointCSP.ts
@@ -44,7 +44,7 @@ function isWorkerSrcValid(
       return false;
     }
     /**
-     * Filter out worker-src that aren't same origin because of the bellow bug
+     * Filter out worker-src that aren't same origin because of the bug below
      * This is safe to do since workers MUST be same-origin by definition
      * https://bugzilla.mozilla.org/show_bug.cgi?id=1847548&fbclid=IwAR3qIyYr5K92_Cw3UJmgtSbgBKwZ5bLppP6LNwN6lC-kQVEdxr_52zeQUPE
      */

--- a/src/js/content/iFrameUtils.ts
+++ b/src/js/content/iFrameUtils.ts
@@ -9,6 +9,14 @@ export function isTopWindow(): boolean {
   return window == window.top;
 }
 
+export function isBlankChildFrame(targetWindow: Window = window): boolean {
+  const href = targetWindow.location.href;
+  return (
+    targetWindow !== targetWindow.top &&
+    (href === 'about:blank' || href.startsWith('about:blank#'))
+  );
+}
+
 export function isSameDomainAsTopWindow(): boolean {
   try {
     // This is inside a try/catch because even attempting to access the `origin`


### PR DESCRIPTION
## Summary

Right now the extension is in an indefinitely processing state when dealing with empty frames. This fixes that by:

- allow empty frames and manifest-only top-level frames to reach a valid state; this fixes the following scenarios which report processing indefinitely:
  1. blank nested frames
  2. a top-level document that does not have any relevant tags to analyze to eventually report either Valid, Timeout, or Invalid state
- let `about:blank` child frames use the shared parent manifest path to verify their resources without waiting for their own manifest (similar to same-origin child frames)
- avoid scheduling a manifest timeout for frames that do not own a manifest and instead rely on their parent's manifest 

## Test plan

- Ran test suite
- Loaded extension locally:
  - ensured it passes for facebook as a smoke test
  - opened console and injected a blank iframe and ensured the extension still reports green