### PR TITLE
Restrict CI workflow token permissions

### DIFF
--- a/.github/workflows/tests.js.yml
+++ b/.github/workflows/tests.js.yml
@@ -3,6 +3,9 @@
 
 name: tests.js CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
## Summary

- declare explicit permissions for the JavaScript CI workflow
- restrict the workflow's `GITHUB_TOKEN` to read-only repository contents

## Security context

Although the workflow does not reference `GITHUB_TOKEN` directly, GitHub creates one for each job and actions such as `actions/checkout` access it through the `github.token` context. Without an explicit `permissions` block, the token inherits the repository or organization defaults.

The workflow only checks out the repository, installs public dependencies, builds, and runs tests, so it does not require write access. `contents: read` is sufficient for checkout. `packages: read` is intentionally omitted because dependencies resolve from the public Yarn registry rather than GitHub Packages.

## Testing

- `yarn build`
- `yarn test` (12 suites passed; 105 tests passed)
- `yarn lint`
- `git diff --check`
