### PR TITLE
Render violation count without HTML parsing

### DIFF
--- a/src/js/__tests__/violation-list-test.js
+++ b/src/js/__tests__/violation-list-test.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import {jest} from '@jest/globals';
+import '../popup/violation-list';
+
+describe('violation-list', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+    window.chrome.storage = {
+      local: {
+        get: jest.fn(async () => ({
+          123: {
+            creationTime: 0,
+            url: 'https://www.facebook.com/',
+            violations: [
+              {
+                hash: 'abc123',
+                origin: 'FACEBOOK',
+                version: '1',
+              },
+            ],
+          },
+        })),
+      },
+    };
+  });
+
+  it('renders the violation count as text when a row is collapsed', async () => {
+    const violationList = document.createElement('violation-list');
+    document.body.appendChild(violationList);
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    const expand = violationList.querySelector('[data-expand-src]');
+    expand.setAttribute('data-violation-count', '<img data-injected="true">');
+
+    expand.click();
+    expand.click();
+
+    expect(expand.textContent).toBe('\u25B6 Show (<img data-injected="true">)');
+    expect(expand.querySelector('[data-injected]')).toBeNull();
+  });
+});

--- a/src/js/popup/violation-list.ts
+++ b/src/js/popup/violation-list.ts
@@ -120,9 +120,9 @@ class ViolationList extends HTMLElement {
             `[data-expand-target="${tabID}"]`,
           )!;
           subtable.classList.toggle('expanded');
-          expand.innerHTML = subtable.classList.contains('expanded')
-            ? `&#9660; Hide`
-            : `&#9654; Show (${expand.getAttribute('data-violation-count')})`;
+          expand.textContent = subtable.classList.contains('expanded')
+            ? `\u25BC Hide`
+            : `\u25B6 Show (${expand.getAttribute('data-violation-count')})`;
         });
       });
     });


### PR DESCRIPTION
## Summary

- render the violation row label with `textContent` instead of `innerHTML`
- use Unicode escapes for the existing expand/collapse arrows so the UI remains unchanged
- add a regression test proving markup-like attribute text is not parsed into DOM elements

## Security context

The popup reads `data-violation-count` and previously interpolated it into `innerHTML` when a violation row was collapsed.

The current value originates from `record.violations.length`, so it is numeric and does not provide a demonstrated attacker-controlled XSS path. Nevertheless, parsing the label as HTML is unnecessary and creates a fragile sink if the value's provenance changes later. Assigning through `textContent` preserves the visible label while ensuring any markup-like value is displayed literally.

## Testing

- added a jsdom regression test using an `<img>`-shaped attribute value and verified that no element is created
- `yarn build`
- `yarn test` (13 suites passed; 106 tests passed)
- `yarn lint`
- `git diff --check`
